### PR TITLE
fix: upgrade Drizzle ORM and Lucide React

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ All notable changes to this project are documented here. The format follows
 
 ### Changed
 
+- Upgrade Drizzle ORM to 0.45.2 and Lucide React to the 1.x line (locked to
+  1.41.0); verify SQLite persistence and icon rendering with regression tests
 - Upgrade i18next/react-i18next together to 26.4.1/17.0.13, tailwind-merge to
   3.6.0 for Tailwind 4, Dagre to 3.1.1, and Zod to 4.5.4 across all workspaces
 - Upgrade React and React DOM together to 19.2.8, Express to 5.2.1, Sonner to

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -33,7 +33,7 @@
     "html-to-image": "^1.11.11",
     "i18next": "^26.4.1",
     "i18next-browser-languagedetector": "^8.0.2",
-    "lucide-react": "^0.469.0",
+    "lucide-react": "^1.38.0",
     "react": "^19.2.8",
     "react-dom": "^19.2.8",
     "react-i18next": "^17.0.13",

--- a/apps/web/src/lib/dependencies.test.ts
+++ b/apps/web/src/lib/dependencies.test.ts
@@ -2,8 +2,19 @@ import { expect, test } from "bun:test";
 import { createElement } from "react";
 import { renderToStaticMarkup } from "react-dom/server";
 import { useTranslation } from "react-i18next";
+import { KIND_ICONS, ROLE_ICONS } from "../features/icons";
 import i18n from "../i18n";
 import { cn } from "./utils";
+
+test("all architecture icons render as SVG with the requested size and class", () => {
+  const icons = new Set([...Object.values(KIND_ICONS), ...Object.values(ROLE_ICONS)]);
+  for (const icon of icons) {
+    const markup = renderToStaticMarkup(createElement(icon, { size: 18, className: "test-icon" }));
+    expect(markup).toContain("<svg");
+    expect(markup).toContain('width="18"');
+    expect(markup).toContain("test-icon");
+  }
+});
 
 test("React translations render in English and Polish", async () => {
   const originalLanguage = i18n.language;

--- a/bun.lock
+++ b/bun.lock
@@ -57,7 +57,7 @@
         "html-to-image": "^1.11.11",
         "i18next": "^26.4.1",
         "i18next-browser-languagedetector": "^8.0.2",
-        "lucide-react": "^0.469.0",
+        "lucide-react": "^1.38.0",
         "react": "^19.2.8",
         "react-dom": "^19.2.8",
         "react-i18next": "^17.0.13",
@@ -89,7 +89,7 @@
       "dependencies": {
         "@structsmith/contracts": "workspace:*",
         "@structsmith/domain": "workspace:*",
-        "drizzle-orm": "^0.38.3",
+        "drizzle-orm": "^0.45.2",
       },
     },
     "packages/domain": {
@@ -546,7 +546,7 @@
 
     "drizzle-kit": ["drizzle-kit@0.31.10", "", { "dependencies": { "@drizzle-team/brocli": "^0.10.2", "@esbuild-kit/esm-loader": "^2.5.5", "esbuild": "^0.25.4", "tsx": "^4.21.0" }, "bin": { "drizzle-kit": "bin.cjs" } }, "sha512-7OZcmQUrdGI+DUNNsKBn1aW8qSoKuTH7d0mYgSP8bAzdFzKoovxEFnoGQp2dVs82EOJeYycqRtciopszwUf8bw=="],
 
-    "drizzle-orm": ["drizzle-orm@0.38.4", "", { "peerDependencies": { "@aws-sdk/client-rds-data": ">=3", "@cloudflare/workers-types": ">=4", "@electric-sql/pglite": ">=0.2.0", "@libsql/client": ">=0.10.0", "@libsql/client-wasm": ">=0.10.0", "@neondatabase/serverless": ">=0.10.0", "@op-engineering/op-sqlite": ">=2", "@opentelemetry/api": "^1.4.1", "@planetscale/database": ">=1", "@prisma/client": "*", "@tidbcloud/serverless": "*", "@types/better-sqlite3": "*", "@types/pg": "*", "@types/react": ">=18", "@types/sql.js": "*", "@vercel/postgres": ">=0.8.0", "@xata.io/client": "*", "better-sqlite3": ">=7", "bun-types": "*", "expo-sqlite": ">=14.0.0", "knex": "*", "kysely": "*", "mysql2": ">=2", "pg": ">=8", "postgres": ">=3", "react": ">=18", "sql.js": ">=1", "sqlite3": ">=5" }, "optionalPeers": ["@aws-sdk/client-rds-data", "@cloudflare/workers-types", "@electric-sql/pglite", "@libsql/client", "@libsql/client-wasm", "@neondatabase/serverless", "@op-engineering/op-sqlite", "@opentelemetry/api", "@planetscale/database", "@prisma/client", "@tidbcloud/serverless", "@types/better-sqlite3", "@types/pg", "@types/react", "@types/sql.js", "@vercel/postgres", "@xata.io/client", "better-sqlite3", "bun-types", "expo-sqlite", "knex", "kysely", "mysql2", "pg", "postgres", "react", "sql.js", "sqlite3"] }, "sha512-s7/5BpLKO+WJRHspvpqTydxFob8i1vo2rEx4pY6TGY7QSMuUfWUuzaY0DIpXCkgHOo37BaFC+SJQb99dDUXT3Q=="],
+    "drizzle-orm": ["drizzle-orm@0.45.2", "", { "peerDependencies": { "@aws-sdk/client-rds-data": ">=3", "@cloudflare/workers-types": ">=4", "@electric-sql/pglite": ">=0.2.0", "@libsql/client": ">=0.10.0", "@libsql/client-wasm": ">=0.10.0", "@neondatabase/serverless": ">=0.10.0", "@op-engineering/op-sqlite": ">=2", "@opentelemetry/api": "^1.4.1", "@planetscale/database": ">=1.13", "@prisma/client": "*", "@tidbcloud/serverless": "*", "@types/better-sqlite3": "*", "@types/pg": "*", "@types/sql.js": "*", "@upstash/redis": ">=1.34.7", "@vercel/postgres": ">=0.8.0", "@xata.io/client": "*", "better-sqlite3": ">=7", "bun-types": "*", "expo-sqlite": ">=14.0.0", "gel": ">=2", "knex": "*", "kysely": "*", "mysql2": ">=2", "pg": ">=8", "postgres": ">=3", "sql.js": ">=1", "sqlite3": ">=5" }, "optionalPeers": ["@aws-sdk/client-rds-data", "@cloudflare/workers-types", "@electric-sql/pglite", "@libsql/client", "@libsql/client-wasm", "@neondatabase/serverless", "@op-engineering/op-sqlite", "@opentelemetry/api", "@planetscale/database", "@prisma/client", "@tidbcloud/serverless", "@types/better-sqlite3", "@types/pg", "@types/sql.js", "@upstash/redis", "@vercel/postgres", "@xata.io/client", "better-sqlite3", "bun-types", "expo-sqlite", "gel", "knex", "kysely", "mysql2", "pg", "postgres", "sql.js", "sqlite3"] }, "sha512-kY0BSaTNYWnoDMVoyY8uxmyHjpJW1geOmBMdSSicKo9CIIWkSxMIj2rkeSR51b8KAPB7m+qysjuHme5nKP+E5Q=="],
 
     "dunder-proto": ["dunder-proto@1.0.1", "", { "dependencies": { "call-bind-apply-helpers": "^1.0.1", "es-errors": "^1.3.0", "gopd": "^1.2.0" } }, "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A=="],
 
@@ -666,7 +666,7 @@
 
     "lightningcss-win32-x64-msvc": ["lightningcss-win32-x64-msvc@1.33.0", "", { "os": "win32", "cpu": "x64" }, "sha512-OlEICDx/Xl0FqSp4bry8zFnCvGpig3Gl4gCquvYwHuqJKEC1+n9NgDniFvqHGmMv1ZkqDJrDqKKSykTDX+ehuA=="],
 
-    "lucide-react": ["lucide-react@0.469.0", "", { "peerDependencies": { "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-28vvUnnKQ/dBwiCQtwJw7QauYnE7yd2Cyp4tTTJpvglX4EMpbflcdBgrgToX2j71B3YvugK/NH3BGUk+E/p/Fw=="],
+    "lucide-react": ["lucide-react@1.41.0", "", { "peerDependencies": { "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-6lksP35l6KszDKUeRTi4LV7i6DEe0Yzl2ALJm9j4c5xEYN91GdW1xGsawGMOg2mgjF5GHBVX8pKX9kP+cWsP3Q=="],
 
     "magic-string": ["magic-string@0.30.21", "", { "dependencies": { "@jridgewell/sourcemap-codec": "^1.5.5" } }, "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ=="],
 

--- a/packages/database/package.json
+++ b/packages/database/package.json
@@ -11,6 +11,6 @@
   "dependencies": {
     "@structsmith/contracts": "workspace:*",
     "@structsmith/domain": "workspace:*",
-    "drizzle-orm": "^0.38.3"
+    "drizzle-orm": "^0.45.2"
   }
 }

--- a/tests/database-persistence.test.ts
+++ b/tests/database-persistence.test.ts
@@ -1,0 +1,44 @@
+import { expect, test } from "bun:test";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { createDatabase, DrizzleStore, runMigrations } from "@structsmith/database";
+import { createServices, InMemoryEventBus } from "@structsmith/domain";
+
+test("SQLite data survives reopening and migrations are not reapplied", () => {
+  const directory = mkdtempSync(join(tmpdir(), "structsmith-persistence-"));
+  const databasePath = join(directory, "test.db");
+  const migrationsDir = fileURLToPath(new URL("../migrations", import.meta.url));
+  const name = "Client's portal — zażółć";
+  try {
+    const first = createDatabase(databasePath);
+    let workspaceId: string;
+    let applied: string[];
+    try {
+      applied = runMigrations(first.sqlite, migrationsDir).applied;
+      expect(applied.length).toBeGreaterThan(0);
+      const services = createServices(new DrizzleStore(first.db), new InMemoryEventBus());
+      workspaceId = services.workspaces.create({ name }).id;
+      services.elements.create(workspaceId, { name: "API", kind: "softwareSystem" });
+    } finally {
+      first.close();
+    }
+
+    const reopened = createDatabase(databasePath);
+    try {
+      const migration = runMigrations(reopened.sqlite, migrationsDir);
+      expect(migration.applied).toEqual([]);
+      expect(migration.skipped).toEqual(applied);
+      const services = createServices(new DrizzleStore(reopened.db), new InMemoryEventBus());
+      expect(services.workspaces.get(workspaceId).name).toBe(name);
+      expect(services.model.get(workspaceId).elements).toHaveLength(1);
+      services.workspaces.update(workspaceId, { name: "Updated" });
+      expect(services.workspaces.get(workspaceId).name).toBe("Updated");
+    } finally {
+      reopened.close();
+    }
+  } finally {
+    rmSync(directory, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
## What and why

- Upgrade drizzle-orm from 0.38.4 to 0.45.2.
- Upgrade lucide-react to the 1.x line: ^1.38.0, resolved to 1.41.0 in bun.lock.
- Add regression tests for all architecture icons and SQLite persistence after reopening, including migration idempotency.
- Update the changelog.

Includes the dependency updates proposed in #20 and #21.

## Verification

- [x] bun install --frozen-lockfile
- [x] bun run check
- [x] bun run typecheck
- [x] bun test — 25 passing tests, 123 assertions
- [x] bun run build
- [x] git diff --check

All checks passed locally. The existing large frontend bundle warning remains. Docker smoke testing was not repeated because local Docker storage previously reported I/O errors.
