### PR TITLE
feat(mcp): add AI client setup guides

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,7 +104,57 @@ MCP is a core feature, not an add-on: it starts with the backend and is served f
 process. The transport is **Streamable HTTP** (the deprecated SSE transport is not
 implemented).
 
-Point any MCP client at the endpoint:
+### Quick install by client
+
+Start StructSmith first, then use the command for your client. The examples assume the public
+Docker image is available at `http://localhost:8090`.
+
+**Codex CLI, Codex Desktop and the Codex IDE extension** share the same MCP configuration:
+
+```bash
+codex mcp add structsmith --url http://localhost:8090/mcp
+```
+
+In Codex Desktop you can instead open **Settings → MCP servers → Add server**, choose
+**Streamable HTTP**, and paste the endpoint. Restart the current session after changing MCP
+configuration.
+
+**Claude Code:**
+
+```bash
+claude mcp add --transport http structsmith http://localhost:8090/mcp
+```
+
+**GitHub Copilot CLI:**
+
+```bash
+copilot mcp add --transport http structsmith http://localhost:8090/mcp
+```
+
+**VS Code with GitHub Copilot** — add `.vscode/mcp.json` to the project where you want to use
+StructSmith:
+
+```json
+{
+  "servers": {
+    "structsmith": {
+      "type": "http",
+      "url": "http://localhost:8090/mcp"
+    }
+  }
+}
+```
+
+Then run **MCP: List Servers** and start `structsmith`; use Copilot Chat in Agent mode.
+
+**Claude Desktop** needs a local STDIO bridge to reach a StructSmith instance on `localhost`.
+See the [AI client installation guide](docs/AI_CLIENTS.md#claude-desktop) for a copy-ready
+configuration. A public HTTPS deployment can instead be added under
+**Customize → Connectors → Add custom connector**, but Claude connects to it from Anthropic's
+cloud — `localhost` will not work there.
+
+For Cursor, Windsurf, JetBrains IDEs and other MCP clients, point a native Streamable HTTP
+connection at the endpoint or use this common configuration shape:
 
 ```json
 {
@@ -117,23 +167,19 @@ Point any MCP client at the endpoint:
 }
 ```
 
-Codex can load StructSmith automatically from a trusted project's `.codex/config.toml`:
+For full client-specific instructions, token authentication, local-development ports and
+troubleshooting, see **[Install StructSmith in AI clients](docs/AI_CLIENTS.md)**. The MCP page in
+StructSmith also generates copy-ready snippets using the live URL, including custom ports.
+
+### Manual Codex configuration
+
+Codex can also load StructSmith automatically from a trusted project's `.codex/config.toml`:
 
 ```toml
 [mcp_servers.structsmith]
 url = "http://localhost:8090/mcp"
 default_tools_approval_mode = "writes"
 tool_timeout_sec = 120
-```
-
-The ChatGPT desktop app, Codex CLI and Codex IDE extension share this project-scoped
-configuration. Start a new local Codex session after adding or changing the server. The MCP page
-in StructSmith always shows a copy-ready snippet with the live URL, including custom ports.
-
-Claude Code, for example:
-
-```bash
-claude mcp add --transport http structsmith http://localhost:8090/mcp
 ```
 
 For clients that only speak stdio:
@@ -350,6 +396,7 @@ stays public. There is no user system — this is a local/self-hosted tool.
 apps/
   web/        React + Vite UI          (React Flow, TanStack Router/Query, Zustand, shadcn-style UI)
   server/     Bun + Express            (REST, MCP transport, SSE, static UI)
+docs/         Client setup and operating guides
 packages/
   contracts/  Zod schemas and DTOs shared by frontend, backend and MCP
   domain/     Pure domain: rules, validation, operations, services (no Express, no SQLite)

--- a/apps/web/src/features/mcp/McpPage.tsx
+++ b/apps/web/src/features/mcp/McpPage.tsx
@@ -1,4 +1,4 @@
-import { ArrowLeft, Check, Copy } from "lucide-react";
+import { ArrowLeft, Check, Copy, ExternalLink } from "lucide-react";
 import { useState } from "react";
 import { useTranslation } from "react-i18next";
 import { toast } from "sonner";
@@ -6,6 +6,8 @@ import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Separator } from "@/components/ui/separator";
 import { useMcpInfo, useSettings } from "@/hooks/useApi";
+
+type ClientId = "codex" | "claudeCode" | "claudeDesktop" | "copilot" | "generic";
 
 const Row = ({ label, children }: { label: string; children: React.ReactNode }) => (
   <div className="flex items-start gap-4 py-2">
@@ -20,28 +22,79 @@ export function McpPage({ onBack }: { onBack: () => void }) {
   const { t } = useTranslation();
   const info = useMcpInfo();
   const settings = useSettings();
-  const [copied, setCopied] = useState<"endpoint" | "codex" | null>(null);
+  const [copied, setCopied] = useState<string | null>(null);
+  const [selectedClient, setSelectedClient] = useState<ClientId>("codex");
 
   const endpoint = info.data?.endpoint ?? `${window.location.origin}/mcp`;
 
-  const copy = async (value: string, target: "endpoint" | "codex"): Promise<void> => {
+  const copy = async (value: string, target: string): Promise<void> => {
     await navigator.clipboard.writeText(value);
     setCopied(target);
     toast.success(t("common.copied"));
     setTimeout(() => setCopied(null), 1500);
   };
 
-  const clientConfig = JSON.stringify(
+  const genericConfig = JSON.stringify(
     { mcpServers: { structsmith: { type: "http", url: endpoint } } },
     null,
     2,
   );
-  const codexConfig = [
-    "[mcp_servers.structsmith]",
-    `url = "${endpoint}"`,
-    'default_tools_approval_mode = "writes"',
-    "tool_timeout_sec = 120",
-  ].join("\n");
+  const clients: Array<{ id: ClientId; label: string; hint: string; snippet: string }> = [
+    {
+      id: "codex",
+      label: t("mcp.clientCodex"),
+      hint: t("mcp.codexHint"),
+      snippet: `codex mcp add structsmith --url ${endpoint}`,
+    },
+    {
+      id: "claudeCode",
+      label: t("mcp.clientClaudeCode"),
+      hint: t("mcp.claudeCodeHint"),
+      snippet: `claude mcp add --transport http structsmith ${endpoint}`,
+    },
+    {
+      id: "claudeDesktop",
+      label: t("mcp.clientClaudeDesktop"),
+      hint: t("mcp.claudeDesktopHint"),
+      snippet: JSON.stringify(
+        {
+          mcpServers: {
+            structsmith: {
+              command: "npx",
+              args: [
+                "-y",
+                "mcp-remote@latest",
+                endpoint,
+                "--transport",
+                "http-only",
+                "--allow-http",
+              ],
+            },
+          },
+        },
+        null,
+        2,
+      ),
+    },
+    {
+      id: "copilot",
+      label: t("mcp.clientCopilot"),
+      hint: t("mcp.copilotHint"),
+      snippet: JSON.stringify(
+        { servers: { structsmith: { type: "http", url: endpoint } } },
+        null,
+        2,
+      ),
+    },
+    {
+      id: "generic",
+      label: t("mcp.clientGeneric"),
+      hint: t("mcp.genericHint"),
+      snippet: genericConfig,
+    },
+  ];
+  const activeClient =
+    clients.find((client) => client.id === selectedClient) ?? (clients[0] as (typeof clients)[0]);
 
   return (
     <div className="h-full overflow-y-auto bg-background">
@@ -96,22 +149,54 @@ export function McpPage({ onBack }: { onBack: () => void }) {
         </div>
 
         <section className="mt-6">
-          <h2 className="text-[13px] font-semibold">{t("mcp.howToTitle")}</h2>
-          <p className="mt-1 text-[12.5px] text-muted-foreground">{t("mcp.howToHint")}</p>
+          <div className="flex items-start justify-between gap-4">
+            <div>
+              <h2 className="text-[13px] font-semibold">{t("mcp.howToTitle")}</h2>
+              <p className="mt-1 text-[12.5px] text-muted-foreground">{t("mcp.howToHint")}</p>
+            </div>
+            <Button variant="link" size="sm" asChild className="shrink-0 px-0">
+              <a
+                href="https://github.com/dziksu/StructSmith/blob/main/docs/AI_CLIENTS.md"
+                target="_blank"
+                rel="noreferrer"
+              >
+                {t("mcp.fullGuide")}
+                <ExternalLink className="h-3 w-3" />
+              </a>
+            </Button>
+          </div>
+
+          <div className="mt-3 flex flex-wrap gap-1 rounded-lg border border-border bg-card p-1">
+            {clients.map((client) => (
+              <Button
+                key={client.id}
+                size="sm"
+                variant={client.id === selectedClient ? "secondary" : "ghost"}
+                onClick={() => setSelectedClient(client.id)}
+              >
+                {client.label}
+              </Button>
+            ))}
+          </div>
+
           <div className="mt-3 flex items-center justify-between">
-            <h3 className="text-[12px] font-medium">{t("mcp.codexConfig")}</h3>
-            <Button size="sm" variant="ghost" onClick={() => void copy(codexConfig, "codex")}>
-              {copied === "codex" ? <Check className="h-3 w-3" /> : <Copy className="h-3 w-3" />}
+            <h3 className="text-[12px] font-medium">{activeClient.label}</h3>
+            <Button
+              size="sm"
+              variant="ghost"
+              onClick={() => void copy(activeClient.snippet, activeClient.id)}
+            >
+              {copied === activeClient.id ? (
+                <Check className="h-3 w-3" />
+              ) : (
+                <Copy className="h-3 w-3" />
+              )}
               {t("common.copy")}
             </Button>
           </div>
-          <p className="mt-1 text-[11.5px] text-muted-foreground">{t("mcp.codexHint")}</p>
+          <p className="mt-1 text-[11.5px] text-muted-foreground">{activeClient.hint}</p>
           <pre className="mt-2 overflow-x-auto rounded-lg border border-border bg-card p-3 font-mono text-[11.5px] leading-relaxed">
-            {codexConfig}
-          </pre>
-          <h3 className="mt-4 text-[12px] font-medium">{t("mcp.genericConfig")}</h3>
-          <pre className="mt-2 overflow-x-auto rounded-lg border border-border bg-card p-3 font-mono text-[11.5px] leading-relaxed">
-            {clientConfig}
+            {activeClient.snippet}
           </pre>
         </section>
 

--- a/apps/web/src/i18n/locales/en.json
+++ b/apps/web/src/i18n/locales/en.json
@@ -253,10 +253,18 @@
     "mutating": "writes",
     "readOnlyTool": "reads",
     "howToTitle": "Connect a client",
-    "howToHint": "Point your MCP client at the Streamable HTTP endpoint above.",
-    "codexConfig": "Codex project configuration",
-    "codexHint": "Add this to .codex/config.toml in a trusted project, then start a new Codex session.",
-    "genericConfig": "Generic configuration"
+    "howToHint": "Choose a client and copy the generated setup using the live endpoint above.",
+    "fullGuide": "Full guide",
+    "clientCodex": "Codex",
+    "clientClaudeCode": "Claude Code",
+    "clientClaudeDesktop": "Claude Desktop",
+    "clientCopilot": "VS Code / Copilot",
+    "clientGeneric": "Other clients",
+    "codexHint": "Run this once. Codex Desktop, CLI and the IDE extension share the same host configuration.",
+    "claudeCodeHint": "Run this command, then use /mcp in Claude Code to verify the connection.",
+    "claudeDesktopHint": "Localhost requires Node.js 18+ and the third-party mcp-remote STDIO bridge. Merge this entry into claude_desktop_config.json and fully restart Claude Desktop.",
+    "copilotHint": "Save this as .vscode/mcp.json, start the server with MCP: List Servers, then use Copilot Chat in Agent mode.",
+    "genericHint": "Use this common shape in clients that support native Streamable HTTP. Some clients call the top-level key servers."
   },
   "settings": {
     "title": "Settings",

--- a/apps/web/src/i18n/locales/pl.json
+++ b/apps/web/src/i18n/locales/pl.json
@@ -257,10 +257,18 @@
     "mutating": "zapis",
     "readOnlyTool": "odczyt",
     "howToTitle": "Podłącz klienta",
-    "howToHint": "Wskaż klientowi MCP powyższy endpoint Streamable HTTP.",
-    "codexConfig": "Konfiguracja projektu Codex",
-    "codexHint": "Dodaj do .codex/config.toml w zaufanym projekcie, a następnie uruchom nową sesję Codex.",
-    "genericConfig": "Konfiguracja ogólna"
+    "howToHint": "Wybierz klienta i skopiuj konfigurację wygenerowaną z aktualnym endpointem.",
+    "fullGuide": "Pełna instrukcja",
+    "clientCodex": "Codex",
+    "clientClaudeCode": "Claude Code",
+    "clientClaudeDesktop": "Claude Desktop",
+    "clientCopilot": "VS Code / Copilot",
+    "clientGeneric": "Inni klienci",
+    "codexHint": "Uruchom raz. Codex Desktop, CLI i rozszerzenie IDE współdzielą konfigurację tego samego hosta.",
+    "claudeCodeHint": "Uruchom komendę, a następnie użyj /mcp w Claude Code, aby sprawdzić połączenie.",
+    "claudeDesktopHint": "Localhost wymaga Node.js 18+ i zewnętrznego mostu STDIO mcp-remote. Dodaj ten wpis do claude_desktop_config.json i całkowicie uruchom ponownie Claude Desktop.",
+    "copilotHint": "Zapisz jako .vscode/mcp.json, uruchom serwer przez MCP: List Servers i użyj Copilot Chat w trybie Agent.",
+    "genericHint": "Użyj tego formatu w klientach z natywnym Streamable HTTP. Niektóre używają klucza servers zamiast mcpServers."
   },
   "settings": {
     "title": "Ustawienia",

--- a/docs/AI_CLIENTS.md
+++ b/docs/AI_CLIENTS.md
@@ -1,0 +1,265 @@
+# Install StructSmith in AI clients
+
+StructSmith exposes one MCP endpoint from the same process as its UI and REST API. An AI client
+connected to it reads and updates the same semantic architecture model that is open in the
+browser.
+
+This guide uses the default Docker endpoint:
+
+```text
+http://localhost:8090/mcp
+```
+
+For local development use `http://localhost:3000/mcp`. For a custom port, open **MCP** in the
+StructSmith top bar and copy the live endpoint shown there.
+
+## Support matrix
+
+| Client | Local `localhost` | Public HTTPS | Recommended setup |
+| --- | --- | --- | --- |
+| Codex Desktop, CLI and IDE | Yes | Yes | Native Streamable HTTP |
+| Claude Code | Yes | Yes | Native Streamable HTTP |
+| Claude Desktop | Yes, through a local bridge | Yes, as a custom connector | Bridge for local; connector for public |
+| GitHub Copilot CLI | Yes | Yes | Native Streamable HTTP |
+| VS Code / Copilot Chat | Yes | Yes | `.vscode/mcp.json` |
+| Cursor, Windsurf and other clients | Client-dependent | Client-dependent | Native HTTP when available; otherwise STDIO bridge |
+
+## Codex Desktop, CLI and IDE extension
+
+The fastest setup is one CLI command:
+
+```bash
+codex mcp add structsmith --url http://localhost:8090/mcp
+```
+
+Codex Desktop, Codex CLI and the Codex IDE extension use the MCP configuration of the same Codex
+host. You can also configure it in Codex Desktop:
+
+1. Open **Settings → MCP servers**.
+2. Select **Add server**.
+3. Enter `structsmith`, choose **Streamable HTTP**, and paste
+   `http://localhost:8090/mcp`.
+4. Save and restart the current session.
+
+For project-scoped configuration, create `.codex/config.toml` in a trusted project:
+
+```toml
+[mcp_servers.structsmith]
+url = "http://localhost:8090/mcp"
+default_tools_approval_mode = "writes"
+tool_timeout_sec = 120
+```
+
+Check the connection with `codex mcp list` or `/mcp` in a Codex session. See the
+[official OpenAI MCP documentation](https://developers.openai.com/codex/mcp/).
+
+## Claude Code
+
+Add the HTTP server directly:
+
+```bash
+claude mcp add --transport http structsmith http://localhost:8090/mcp
+```
+
+Run `/mcp` inside Claude Code to inspect the connection and available tools. To share the setup
+with a team, use a project `.mcp.json`:
+
+```json
+{
+  "mcpServers": {
+    "structsmith": {
+      "type": "http",
+      "url": "http://localhost:8090/mcp"
+    }
+  }
+}
+```
+
+See the [official Claude Code MCP documentation](https://docs.anthropic.com/en/docs/claude-code/mcp).
+
+## Claude Desktop
+
+Claude Desktop has two different connection paths. Choose the one that matches where
+StructSmith runs.
+
+### Local StructSmith on `localhost`
+
+Claude Desktop's local MCP configuration launches STDIO processes. To connect that mechanism to
+StructSmith's Streamable HTTP endpoint, use the third-party
+[`mcp-remote`](https://github.com/geelen/mcp-remote) bridge. It requires Node.js 18 or newer.
+
+Open Claude Desktop once, then edit its configuration file:
+
+- macOS: `~/Library/Application Support/Claude/claude_desktop_config.json`
+- Windows: `%APPDATA%\Claude\claude_desktop_config.json`
+
+Merge this entry with any existing `mcpServers` entries:
+
+```json
+{
+  "mcpServers": {
+    "structsmith": {
+      "command": "npx",
+      "args": [
+        "-y",
+        "mcp-remote@latest",
+        "http://localhost:8090/mcp",
+        "--transport",
+        "http-only",
+        "--allow-http"
+      ]
+    }
+  }
+}
+```
+
+Fully quit and reopen Claude Desktop. If the app cannot find `npx`, replace `"npx"` with the
+absolute path returned by `which npx` (macOS/Linux) or `where npx` (Windows).
+
+`mcp-remote` is an independent, experimental compatibility bridge; review it before allowing
+write tools. A native StructSmith `.mcpb` desktop extension is not currently published.
+
+### Public StructSmith over HTTPS
+
+In Claude Desktop open **Customize → Connectors**, select **Add custom connector**, and enter the
+public MCP URL. This connection originates from Anthropic's cloud, not from the desktop app, so
+`localhost`, private LAN addresses and VPN-only hosts are not reachable through this path.
+
+Do not publish an unauthenticated StructSmith instance to the internet. StructSmith currently
+supports static bearer-token authentication rather than OAuth, so confirm that your chosen
+connector or gateway can supply the required `Authorization` header. See Anthropic's
+[remote connector guide](https://support.claude.com/en/articles/11175166-get-started-with-custom-connectors-using-remote-mcp)
+and [desktop extension guide](https://support.claude.com/en/articles/10949351-getting-started-with-local-mcp-servers-on-claude-desktop).
+
+## GitHub Copilot CLI
+
+Add StructSmith with one command:
+
+```bash
+copilot mcp add --transport http structsmith http://localhost:8090/mcp
+```
+
+Verify it with `copilot mcp list`. For a shared repository configuration, use `.mcp.json` or
+`.github/mcp.json`:
+
+```json
+{
+  "mcpServers": {
+    "structsmith": {
+      "type": "http",
+      "url": "http://localhost:8090/mcp",
+      "tools": ["*"]
+    }
+  }
+}
+```
+
+Project-level servers load only after the folder is trusted. Copilot CLI does not read
+`.vscode/mcp.json`; use one of the project files above for the CLI. See the
+[official GitHub Copilot CLI instructions](https://docs.github.com/en/copilot/how-tos/copilot-cli/customize-copilot/add-mcp-servers).
+
+## VS Code with GitHub Copilot
+
+Create `.vscode/mcp.json` in the project where Copilot should use StructSmith:
+
+```json
+{
+  "servers": {
+    "structsmith": {
+      "type": "http",
+      "url": "http://localhost:8090/mcp"
+    }
+  }
+}
+```
+
+Save the file, approve the workspace trust prompt, and run **MCP: List Servers** from the command
+palette. Use Copilot Chat in **Agent** mode so it can invoke tools. See the
+[VS Code MCP configuration reference](https://code.visualstudio.com/docs/agents/reference/mcp-configuration).
+
+## Cursor, Windsurf, JetBrains and other clients
+
+Prefer a native Streamable HTTP server definition when the client supports it:
+
+```json
+{
+  "mcpServers": {
+    "structsmith": {
+      "type": "http",
+      "url": "http://localhost:8090/mcp"
+    }
+  }
+}
+```
+
+Some clients use `servers` instead of `mcpServers`, or omit `type`. Use the client's MCP settings
+screen when available. For a STDIO-only client, use the same `mcp-remote` bridge shown for Claude
+Desktop, or run StructSmith from source with `bun run mcp:stdio`.
+
+## Token authentication
+
+The local default has no authentication. Before exposing StructSmith outside your machine, set
+`AUTH_MODE=token`, set a strong `APP_TOKEN`, and put TLS in front of it. Never commit the token to
+a repository.
+
+Clients with native HTTP headers should send:
+
+```text
+Authorization: Bearer YOUR_TOKEN
+```
+
+Claude Code and Copilot CLI accept the header during installation:
+
+```bash
+claude mcp add --transport http structsmith https://structsmith.example.com/mcp \
+  --header "Authorization: Bearer YOUR_TOKEN"
+
+copilot mcp add --transport http structsmith https://structsmith.example.com/mcp \
+  --header "Authorization: Bearer YOUR_TOKEN"
+```
+
+For Codex, keep the token in an environment variable:
+
+```toml
+[mcp_servers.structsmith]
+url = "https://structsmith.example.com/mcp"
+bearer_token_env_var = "STRUCTSMITH_TOKEN"
+```
+
+For VS Code, use an input variable so the token is stored outside the configuration file:
+
+```json
+{
+  "inputs": [
+    {
+      "type": "promptString",
+      "id": "structsmith-token",
+      "description": "StructSmith access token",
+      "password": true
+    }
+  ],
+  "servers": {
+    "structsmith": {
+      "type": "http",
+      "url": "https://structsmith.example.com/mcp",
+      "headers": {
+        "Authorization": "Bearer ${input:structsmith-token}"
+      }
+    }
+  }
+}
+```
+
+See [SECURITY.md](../SECURITY.md) before making the service reachable outside localhost.
+
+## Verify and troubleshoot
+
+1. Open the StructSmith **MCP** page and confirm that the endpoint is running.
+2. Check `http://localhost:8090/health` in a browser or with `curl`.
+3. List MCP servers in the client and confirm that `structsmith` exposes tools.
+4. Start with `workspace_list`, then call `workspace_inspect` for one workspace.
+5. If Docker is running on a different machine, replace `localhost` with that machine's reachable
+   hostname and secure the connection.
+
+Cloud agents cannot reach a service bound to your laptop's `localhost`. Use a secured HTTPS
+deployment or a client feature that runs MCP locally on the same machine as StructSmith.


### PR DESCRIPTION
## What and why

Make StructSmith's MCP setup copy-ready for the AI clients people actually use:

- add one-command setup to the README for Codex, Claude Code and Copilot CLI, plus VS Code configuration
- add a detailed client guide covering Codex Desktop, Claude Desktop local and public connection paths, Claude Code, Copilot, VS Code, other clients, token authentication and troubleshooting
- expand the in-app MCP page with client-specific snippets generated from the live endpoint
- document the important Claude Desktop distinction: localhost needs a local STDIO bridge, while custom connectors connect from Anthropic's cloud

The instructions were checked against the current official OpenAI, Anthropic, GitHub and VS Code documentation.

## How to verify

1. Run `bun run dev` and open `/settings/mcp`.
2. Switch among Codex, Claude Code, Claude Desktop, VS Code / Copilot and Other clients.
3. Confirm every snippet contains the live MCP endpoint and the copy action copies the selected snippet.
4. Review `README.md` and `docs/AI_CLIENTS.md`.
5. Run:
   - `bun run check`
   - `bun run typecheck`
   - `bun run test`
   - `bun run build`

## Checklist

- [x] `bun run check`, `bun run typecheck`, `bun run test` and `bun run build` pass
- [x] The semantic model stays the source of truth — no data lives only in React Flow state
- [x] Layout changes touch views, not elements (not applicable; no layout changes)
- [x] REST and MCP still go through the same domain services
- [x] New DTOs are defined in `packages/contracts` (not applicable; no new DTOs)
- [x] User-facing copy goes through i18n (`en` and `pl` locales updated)
