### PR TITLE
feat(site): add marketing site and GitHub Pages deployment

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,6 +41,9 @@ jobs:
       - name: Build the web app
         run: bun run build
 
+      - name: Build the marketing site
+        run: bun run build:site
+
   docker:
     name: Docker image builds
     runs-on: ubuntu-latest

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,0 +1,58 @@
+name: GitHub Pages
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "apps/site/**"
+      - "public/**"
+      - "package.json"
+      - "bun.lock"
+      - ".github/workflows/pages.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: github-pages
+  cancel-in-progress: true
+
+jobs:
+  build:
+    name: Build marketing site
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Build site
+        run: bun run build:site
+
+      - name: Configure GitHub Pages
+        uses: actions/configure-pages@v6
+
+      - name: Upload site artifact
+        uses: actions/upload-pages-artifact@v5
+        with:
+          path: apps/site/dist
+
+  deploy:
+    name: Deploy to GitHub Pages
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Deploy
+        id: deployment
+        uses: actions/deploy-pages@v5

--- a/README.md
+++ b/README.md
@@ -83,6 +83,18 @@ on <http://localhost:5173>, which proxies `/api` and `/mcp` to the backend. The 
 database is created and migrated automatically — no Docker, Postgres, Redis, Java or Python
 required for development.
 
+The static project website lives in `apps/site`. Run it separately on
+<http://localhost:4174> with:
+
+```bash
+bun run dev:site
+```
+
+`bun run build:site` creates the GitHub Pages artifact in `apps/site/dist`. Changes to the
+site, shared public assets, or its workflow are published automatically from `main` by the
+`GitHub Pages` action. Before the first deployment, select **GitHub Actions** as the source in
+the repository's **Settings → Pages**; later pushes need no manual publishing step.
+
 ---
 
 ## Endpoints

--- a/apps/site/index.html
+++ b/apps/site/index.html
@@ -1,0 +1,124 @@
+<!doctype html>
+<html lang="en" prefix="og: https://ogp.me/ns#">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="theme-color" content="#0d1015" />
+    <meta name="color-scheme" content="dark" />
+    <meta name="application-name" content="StructSmith" />
+    <meta name="author" content="StructSmith contributors" />
+    <meta
+      name="robots"
+      content="index, follow, max-image-preview:large, max-snippet:-1, max-video-preview:-1"
+    />
+    <link rel="icon" type="image/png" href="%BASE_URL%logo.png" />
+    <link rel="canonical" href="https://dziksu.github.io/StructSmith/" />
+    <link
+      rel="alternate"
+      type="text/markdown"
+      href="https://dziksu.github.io/StructSmith/index.md"
+    />
+    <link rel="describedby" href="https://dziksu.github.io/StructSmith/llms.txt" />
+    <link rel="alternate" hreflang="en" href="https://dziksu.github.io/StructSmith/" />
+    <link rel="alternate" hreflang="x-default" href="https://dziksu.github.io/StructSmith/" />
+    <meta
+      name="description"
+      content="Open-source, self-hosted alternative to paid architecture tools. Model C4-inspired systems locally and work on the same semantic model with AI through MCP."
+    />
+    <meta property="og:type" content="website" />
+    <meta property="og:site_name" content="StructSmith" />
+    <meta property="og:locale" content="en_US" />
+    <meta
+      property="og:title"
+      content="StructSmith — Open-source architecture modelling with AI"
+    />
+    <meta
+      property="og:description"
+      content="A local-first, self-hosted alternative to paid architecture tools. One semantic model for people, REST APIs and AI clients through MCP."
+    />
+    <meta property="og:url" content="https://dziksu.github.io/StructSmith/" />
+    <meta
+      property="og:image"
+      content="https://dziksu.github.io/StructSmith/screen_01.png"
+    />
+    <meta property="og:image:secure_url" content="https://dziksu.github.io/StructSmith/screen_01.png" />
+    <meta property="og:image:type" content="image/png" />
+    <meta property="og:image:width" content="1919" />
+    <meta property="og:image:height" content="960" />
+    <meta
+      property="og:image:alt"
+      content="StructSmith showing a software architecture system context diagram"
+    />
+    <meta name="twitter:card" content="summary_large_image" />
+    <meta name="twitter:title" content="StructSmith — Open-source architecture modelling with AI" />
+    <meta
+      name="twitter:description"
+      content="Model software architecture locally and let AI clients work on the same semantic model through MCP."
+    />
+    <meta name="twitter:image" content="https://dziksu.github.io/StructSmith/screen_01.png" />
+    <meta
+      name="twitter:image:alt"
+      content="StructSmith showing a software architecture system context diagram"
+    />
+    <script type="application/ld+json">
+      {
+        "@context": "https://schema.org",
+        "@graph": [
+          {
+            "@type": "WebSite",
+            "@id": "https://dziksu.github.io/StructSmith/#website",
+            "url": "https://dziksu.github.io/StructSmith/",
+            "name": "StructSmith",
+            "description": "Open-source, local-first software architecture modelling for humans and AI clients.",
+            "inLanguage": "en"
+          },
+          {
+            "@type": "SoftwareApplication",
+            "@id": "https://dziksu.github.io/StructSmith/#software",
+            "name": "StructSmith",
+            "url": "https://dziksu.github.io/StructSmith/",
+            "description": "A free, self-hosted alternative to paid software architecture tools with a visual editor, a semantic C4-inspired model, REST API and built-in MCP server.",
+            "applicationCategory": "DeveloperApplication",
+            "applicationSubCategory": "Software architecture modelling",
+            "operatingSystem": "Linux, macOS, Windows",
+            "softwareRequirements": "Docker or Bun 1.2 or newer",
+            "isAccessibleForFree": true,
+            "license": "https://github.com/dziksu/StructSmith/blob/main/LICENSE",
+            "downloadUrl": "https://github.com/dziksu/StructSmith/releases",
+            "sameAs": "https://github.com/dziksu/StructSmith",
+            "offers": {
+              "@type": "Offer",
+              "price": "0",
+              "priceCurrency": "USD"
+            },
+            "featureList": [
+              "C4-inspired semantic architecture model",
+              "Visual React Flow editor",
+              "Built-in Model Context Protocol server",
+              "REST API",
+              "Local SQLite persistence",
+              "Snapshots and revision-guarded changes",
+              "Docker self-hosting"
+            ]
+          },
+          {
+            "@type": "SoftwareSourceCode",
+            "name": "StructSmith source code",
+            "codeRepository": "https://github.com/dziksu/StructSmith",
+            "license": "https://github.com/dziksu/StructSmith/blob/main/LICENSE",
+            "programmingLanguage": ["TypeScript", "JavaScript"],
+            "runtimePlatform": "Bun",
+            "targetProduct": {
+              "@id": "https://dziksu.github.io/StructSmith/#software"
+            }
+          }
+        ]
+      }
+    </script>
+    <title>StructSmith — Open-source architecture modelling with AI</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/apps/site/package.json
+++ b/apps/site/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "@structsmith/site",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "lucide-react": "^1.38.0",
+    "react": "^19.2.8",
+    "react-dom": "^19.2.8"
+  },
+  "devDependencies": {
+    "@types/react": "^19.2.18",
+    "@types/react-dom": "^19.2.5",
+    "@vitejs/plugin-react": "^6.1.1",
+    "vite": "^8.2.2"
+  }
+}

--- a/apps/site/src/App.tsx
+++ b/apps/site/src/App.tsx
@@ -1,0 +1,481 @@
+import {
+  ArrowRight,
+  Blocks,
+  Bot,
+  Check,
+  Database,
+  GitFork as Github,
+  GitPullRequest,
+  Layers3,
+  LockKeyhole,
+  MonitorCog,
+  Network,
+  ScanLine,
+  Sparkles,
+  Terminal,
+} from "lucide-react";
+
+const githubUrl = "https://github.com/dziksu/StructSmith";
+
+function ArchitectureCanvas() {
+  return (
+    <div
+      className="architecture-demo"
+      role="img"
+      aria-label="An animated StructSmith architecture model being assembled"
+    >
+      <div className="demo-toolbar">
+        <span>
+          <i className="status-dot" /> Container view
+        </span>
+        <span className="demo-revision">revision 28</span>
+      </div>
+      <div className="demo-canvas">
+        <svg
+          className="demo-edges"
+          viewBox="0 0 680 400"
+          preserveAspectRatio="none"
+          aria-hidden="true"
+        >
+          <path className="edge edge-one" d="M150 157 C205 157 210 87 250 87" />
+          <path className="edge edge-two" d="M398 87 C454 87 468 47 532 47" />
+          <path className="edge edge-three edge-async" d="M398 87 C470 87 466 195 532 195" />
+          <path className="edge edge-four" d="M398 87 C474 87 466 339 532 339" />
+        </svg>
+        <div className="arch-node person-node">
+          <i className="node-port node-port-out" />
+          <span className="node-icon">P</span>
+          <strong>Product team</strong>
+          <small>PERSON</small>
+        </div>
+        <div className="arch-node system-node">
+          <i className="node-port node-port-in" />
+          <i className="node-port node-port-out" />
+          <span className="node-icon">S</span>
+          <strong>StructSmith</strong>
+          <span>Architecture workspace</span>
+          <small>SOFTWARE SYSTEM</small>
+        </div>
+        <div className="arch-node api-node">
+          <i className="node-port node-port-in" />
+          <span className="node-icon">A</span>
+          <strong>REST API</strong>
+          <small>CONTAINER · BUN</small>
+        </div>
+        <div className="arch-node mcp-node">
+          <i className="node-port node-port-in" />
+          <span className="node-icon">M</span>
+          <strong>MCP server</strong>
+          <small>CONTAINER · HTTP</small>
+        </div>
+        <div className="arch-node db-node">
+          <i className="node-port node-port-in" />
+          <span className="node-icon">D</span>
+          <strong>Model store</strong>
+          <small>CONTAINER · SQLITE</small>
+        </div>
+        <span className="edge-label label-one">models architecture</span>
+        <span className="edge-label label-two">same domain model</span>
+        <div className="model-event">
+          <span>+</span> relationship created
+        </div>
+      </div>
+      <div className="demo-footer">
+        <span>5 elements</span>
+        <span>4 relationships</span>
+        <span className="mcp-live">
+          <i /> MCP connected
+        </span>
+      </div>
+    </div>
+  );
+}
+
+export function App() {
+  return (
+    <main>
+      <nav className="site-nav" aria-label="Primary navigation">
+        <a className="brand" href="#top" aria-label="StructSmith home">
+          <img src={`${import.meta.env.BASE_URL}logo.png`} alt="" />
+          <span>StructSmith</span>
+        </a>
+        <div className="nav-links">
+          <a href="#why">Why StructSmith</a>
+          <a href="#mcp">MCP</a>
+          <a href="#start">Quick start</a>
+          <a className="github-link" href={githubUrl} target="_blank" rel="noreferrer">
+            <Github aria-hidden="true" /> GitHub
+          </a>
+        </div>
+      </nav>
+
+      <section className="hero" id="top">
+        <div className="hero-copy">
+          <div className="eyebrow">
+            <span /> Open source · local-first · MCP-native
+          </div>
+          <h1>
+            Architecture that stays useful <em>after the workshop.</em>
+          </h1>
+          <p>
+            The open-source, self-hosted alternative to paid architecture tools. Model software
+            systems with people and AI on the same source of truth — without accounts, cloud
+            lock-in, or diagrams that drift away from reality.
+          </p>
+          <div className="hero-actions">
+            <a className="button button-primary" href="#start">
+              Run StructSmith <ArrowRight />
+            </a>
+            <a
+              className="button button-secondary"
+              href={githubUrl}
+              target="_blank"
+              rel="noreferrer"
+            >
+              <Github /> View source
+            </a>
+          </div>
+          <div className="hero-proof">
+            <span>
+              <strong>1</strong> container
+            </span>
+            <span>
+              <strong>1</strong> SQLite file
+            </span>
+            <span>
+              <strong>0</strong> telemetry
+            </span>
+          </div>
+        </div>
+        <ArchitectureCanvas />
+      </section>
+
+      <section className="model-strip" aria-label="One model shared by every interface">
+        <p>One semantic model. Every way of working.</p>
+        <div className="model-strip-flow">
+          <span>
+            <MonitorCog /> Visual editor
+          </span>
+          <i />
+          <span>
+            <Terminal /> REST API
+          </span>
+          <i />
+          <span>
+            <Sparkles /> AI via MCP
+          </span>
+          <b>→</b>
+          <strong>
+            <Database /> Domain model + SQLite
+          </strong>
+        </div>
+      </section>
+
+      <section className="product-section section-shell" id="why">
+        <div className="section-heading split-heading">
+          <div>
+            <span className="section-kicker">Not another drawing canvas</span>
+            <h2>
+              Your diagram is a view.
+              <br />
+              The model is the truth.
+            </h2>
+          </div>
+          <p>
+            Every element, relationship, boundary and view remains structured. Change the model in
+            the editor, through REST, or with an AI assistant — the architecture stays consistent
+            everywhere.
+          </p>
+        </div>
+
+        <div className="product-frame">
+          <div className="browser-chrome">
+            <div className="traffic-lights">
+              <i />
+              <i />
+              <i />
+            </div>
+            <span>StructSmith / System context</span>
+            <span className="browser-status">
+              <i /> MCP
+            </span>
+          </div>
+          <img
+            src={`${import.meta.env.BASE_URL}screen_01.png`}
+            alt="StructSmith system context diagram in the visual editor"
+          />
+          <div className="frame-callout callout-model">
+            <Network />
+            <span>
+              <strong>Semantic by design</strong>Elements are more than boxes
+            </span>
+          </div>
+          <div className="frame-callout callout-sync">
+            <ScanLine />
+            <span>
+              <strong>Always in sync</strong>AI changes appear live
+            </span>
+          </div>
+        </div>
+      </section>
+
+      <section className="feature-section section-shell">
+        <div className="section-heading compact-heading">
+          <span className="section-kicker">
+            A practical alternative to paid architecture suites
+          </span>
+          <h2>
+            Enough structure to stay useful.
+            <br />
+            Light enough to keep using.
+          </h2>
+        </div>
+
+        <div className="feature-grid">
+          <article className="feature-card feature-card-wide model-card">
+            <div className="feature-icon">
+              <Layers3 />
+            </div>
+            <div>
+              <h3>Model systems, not slides</h3>
+              <p>
+                C4-inspired elements, typed relationships, boundaries, views and presets live in one
+                validated workspace.
+              </p>
+            </div>
+            <div className="mini-stack" aria-hidden="true">
+              <div>
+                <span>01</span>System context<i>7 elements</i>
+              </div>
+              <div>
+                <span>02</span>Containers<i>12 elements</i>
+              </div>
+              <div>
+                <span>03</span>Deployment<i>8 elements</i>
+              </div>
+            </div>
+          </article>
+
+          <article className="feature-card local-card">
+            <div className="feature-icon">
+              <LockKeyhole />
+            </div>
+            <h3>Local means local</h3>
+            <p>
+              No account, cloud dependency or telemetry. One container and one SQLite file keep
+              ownership simple.
+            </p>
+            <div className="local-proof" aria-hidden="true">
+              <span>
+                <Check /> No sign-up
+              </span>
+              <span>
+                <Check /> Offline-ready
+              </span>
+              <span>
+                <Check /> MIT licensed
+              </span>
+            </div>
+          </article>
+
+          <article className="feature-card collaboration-card">
+            <div className="feature-icon">
+              <GitPullRequest />
+            </div>
+            <h3>Change without fear</h3>
+            <p>
+              Revision guards, automatic snapshots and operation previews make larger model changes
+              reviewable.
+            </p>
+            <div className="revision-track" aria-hidden="true">
+              <i>26</i>
+              <span />
+              <i>27</i>
+              <span />
+              <i className="active-rev">28</i>
+            </div>
+          </article>
+
+          <article className="feature-card feature-card-wide mcp-card" id="mcp">
+            <div className="mcp-copy">
+              <div className="feature-icon">
+                <Bot />
+              </div>
+              <h3>AI works on the architecture — not a screenshot</h3>
+              <p>
+                The built-in MCP server gives Codex, Claude, Copilot and other clients the same
+                validated tools the UI uses. Inspect, model, review and document without translating
+                the system into chat.
+              </p>
+              <a
+                href={`${githubUrl}/blob/main/docs/AI_CLIENTS.md`}
+                target="_blank"
+                rel="noreferrer"
+              >
+                Connect your AI client <ArrowRight className="mcp-link-icon" />
+              </a>
+            </div>
+            <div className="mcp-terminal">
+              <div className="terminal-top">
+                <span>
+                  <i />
+                  <i />
+                  <i />
+                </span>
+                <b>AI client · StructSmith MCP</b>
+              </div>
+              <div className="terminal-line user-line">
+                <span>you</span>Add a notification worker and connect it to the API.
+              </div>
+              <div className="terminal-line tool-line">
+                <span>tool</span>model_apply_operations
+              </div>
+              <div className="terminal-result">
+                <span>
+                  <Check className="terminal-result-icon" /> 3 operations applied
+                </span>
+                <code>revision 28 → 29</code>
+              </div>
+              <div className="terminal-line assistant-line">
+                <span>ai</span>The worker, queue relationship and container view are updated.
+              </div>
+            </div>
+          </article>
+        </div>
+      </section>
+
+      <section className="workflow-section section-shell">
+        <div className="section-heading workflow-heading">
+          <span className="section-kicker">A shared architecture loop</span>
+          <h2>Think together. Change once. See it everywhere.</h2>
+        </div>
+        <div className="workflow-grid">
+          <article>
+            <span className="workflow-step">01</span>
+            <Blocks className="workflow-icon" />
+            <h3>Shape the model</h3>
+            <p>
+              Capture people, systems, containers and the relationships that make the design
+              understandable.
+            </p>
+          </article>
+          <article>
+            <span className="workflow-step">02</span>
+            <Bot className="workflow-icon" />
+            <h3>Explore with AI</h3>
+            <p>
+              Ask for risks, unknowns, alternatives or a complete model update through structured
+              MCP tools.
+            </p>
+          </article>
+          <article>
+            <span className="workflow-step">03</span>
+            <Network className="workflow-icon" />
+            <h3>Share the right view</h3>
+            <p>
+              Create system context, container and tailored stakeholder views from the same source
+              of truth.
+            </p>
+          </article>
+        </div>
+      </section>
+
+      <section className="start-section section-shell" id="start">
+        <div className="start-copy">
+          <span className="section-kicker">Up in under a minute</span>
+          <h2>
+            Your architecture workspace,
+            <br />
+            without the platform tax.
+          </h2>
+          <p>
+            Run the published image locally. Your model persists in a Docker volume and never leaves
+            your machine.
+          </p>
+          <div className="start-points">
+            <span className="start-point">
+              <Check className="start-check" /> Single command
+            </span>
+            <span className="start-point">
+              <Check className="start-check" /> No configuration required
+            </span>
+            <span className="start-point">
+              <Check className="start-check" /> Works fully offline
+            </span>
+          </div>
+        </div>
+        <div className="install-panel">
+          <div className="install-tabs">
+            <span className="install-tab-active">
+              <Terminal className="install-tab-icon" /> Docker
+            </span>
+            <span>localhost:8090</span>
+          </div>
+          <pre>
+            <code>
+              <span>$</span>{" "}
+              {`docker run -d --name structsmith \\
+  -p 127.0.0.1:8090:8080 \\
+  -v structsmith-data:/data \\
+  ghcr.io/dziksu/structsmith:latest`}
+            </code>
+          </pre>
+          <div className="install-ready">
+            <i />
+            <span className="install-ready-copy">
+              <strong>StructSmith is ready</strong>Open http://localhost:8090
+            </span>
+          </div>
+          <a
+            className="button button-primary install-button"
+            href={`${githubUrl}#quick-start`}
+            target="_blank"
+            rel="noreferrer"
+          >
+            Read the quick start <ArrowRight />
+          </a>
+        </div>
+      </section>
+
+      <section className="final-cta section-shell">
+        <div className="cta-mark" aria-hidden="true">
+          <Network className="cta-icon" />
+        </div>
+        <h2>Make architecture a living part of the work.</h2>
+        <p>Open source, self-hosted and ready to collaborate with your AI client.</p>
+        <div className="hero-actions">
+          <a
+            className="button button-primary"
+            href={`${githubUrl}#quick-start`}
+            target="_blank"
+            rel="noreferrer"
+          >
+            Start locally <ArrowRight />
+          </a>
+          <a className="button button-secondary" href={githubUrl} target="_blank" rel="noreferrer">
+            <Github /> Star on GitHub
+          </a>
+        </div>
+      </section>
+
+      <footer className="site-footer section-shell">
+        <a className="brand" href="#top">
+          <img src={`${import.meta.env.BASE_URL}logo.png`} alt="" />
+          <span>StructSmith</span>
+        </a>
+        <p>Model, document and share software architecture — locally, and with your AI client.</p>
+        <div>
+          <a href={`${githubUrl}/blob/main/LICENSE`} target="_blank" rel="noreferrer">
+            MIT License
+          </a>
+          <a href={`${githubUrl}/releases`} target="_blank" rel="noreferrer">
+            Releases
+          </a>
+          <a href={githubUrl} target="_blank" rel="noreferrer">
+            GitHub
+          </a>
+        </div>
+      </footer>
+    </main>
+  );
+}

--- a/apps/site/src/main.tsx
+++ b/apps/site/src/main.tsx
@@ -1,0 +1,16 @@
+import { StrictMode } from "react";
+import { createRoot } from "react-dom/client";
+import { App } from "./App";
+import "./styles.css";
+
+const root = document.getElementById("root");
+
+if (!root) {
+  throw new Error("StructSmith site root element was not found");
+}
+
+createRoot(root).render(
+  <StrictMode>
+    <App />
+  </StrictMode>,
+);

--- a/apps/site/src/styles.css
+++ b/apps/site/src/styles.css
@@ -1,0 +1,1442 @@
+:root {
+  color-scheme: dark;
+  font-family:
+    Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  color: #eef1f6;
+  background: #0d1015;
+  font-synthesis: none;
+  text-rendering: optimizeLegibility;
+  --bg: #0d1015;
+  --panel: #141820;
+  --panel-soft: #11151c;
+  --line: #29313d;
+  --muted: #9199a8;
+  --blue: #6d8fff;
+  --blue-bright: #8ea8ff;
+  --green: #6ed6a6;
+}
+
+* {
+  box-sizing: border-box;
+}
+html {
+  scroll-behavior: smooth;
+}
+body {
+  margin: 0;
+  min-width: 320px;
+  min-height: 100vh;
+  background: var(--bg);
+}
+a {
+  color: inherit;
+  text-decoration: none;
+}
+button,
+a {
+  -webkit-tap-highlight-color: transparent;
+}
+
+body::before {
+  position: fixed;
+  inset: 0;
+  z-index: -2;
+  content: "";
+  background:
+    radial-gradient(circle at 72% 12%, rgba(88, 119, 234, 0.13), transparent 30rem),
+    linear-gradient(rgba(255, 255, 255, 0.012) 1px, transparent 1px),
+    linear-gradient(90deg, rgba(255, 255, 255, 0.012) 1px, transparent 1px);
+  background-size:
+    auto,
+    64px 64px,
+    64px 64px;
+}
+
+main {
+  overflow: hidden;
+}
+.site-nav {
+  width: min(1180px, calc(100% - 40px));
+  height: 72px;
+  margin: 0 auto;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.08);
+}
+.brand {
+  display: inline-flex;
+  align-items: center;
+  gap: 10px;
+  font-size: 1rem;
+  font-weight: 650;
+  letter-spacing: -0.02em;
+}
+.brand img {
+  width: 28px;
+  height: 28px;
+  object-fit: contain;
+}
+.nav-links {
+  display: flex;
+  align-items: center;
+  gap: 28px;
+  color: #abb2bf;
+  font-size: 0.875rem;
+}
+.nav-links a {
+  transition: color 160ms ease;
+}
+.nav-links a:hover {
+  color: #fff;
+}
+.github-link {
+  display: inline-flex;
+  align-items: center;
+  gap: 7px;
+}
+.github-link svg {
+  width: 17px;
+  height: 17px;
+}
+
+.hero {
+  width: min(1180px, calc(100% - 40px));
+  min-height: calc(100vh - 72px);
+  margin: 0 auto;
+  padding: 82px 0 104px;
+  display: grid;
+  grid-template-columns: minmax(0, 0.83fr) minmax(560px, 1.17fr);
+  gap: 72px;
+  align-items: center;
+}
+.hero-copy {
+  position: relative;
+  z-index: 2;
+}
+.eyebrow {
+  display: flex;
+  align-items: center;
+  gap: 9px;
+  margin-bottom: 26px;
+  color: #b4bdcc;
+  font-size: 0.76rem;
+  font-weight: 650;
+  letter-spacing: 0.105em;
+  text-transform: uppercase;
+}
+.eyebrow span {
+  width: 7px;
+  height: 7px;
+  border-radius: 50%;
+  background: var(--green);
+  box-shadow: 0 0 0 5px rgba(110, 214, 166, 0.09);
+}
+h1 {
+  max-width: 670px;
+  margin: 0;
+  font-size: clamp(3.15rem, 6vw, 5.45rem);
+  line-height: 0.96;
+  letter-spacing: -0.065em;
+  font-weight: 650;
+}
+h1 em {
+  color: #98a8d7;
+  font-style: normal;
+}
+.hero-copy > p {
+  max-width: 590px;
+  margin: 28px 0 0;
+  color: #a6afbd;
+  font-size: 1.08rem;
+  line-height: 1.7;
+}
+.hero-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+  margin-top: 36px;
+}
+.button {
+  min-height: 48px;
+  padding: 0 19px;
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 9px;
+  font-size: 0.9rem;
+  font-weight: 650;
+  transition:
+    transform 160ms ease,
+    border-color 160ms ease,
+    background 160ms ease;
+}
+.button svg {
+  width: 17px;
+  height: 17px;
+}
+.button:hover {
+  transform: translateY(-2px);
+}
+.button-primary {
+  color: #0f1420;
+  background: var(--blue-bright);
+  border-color: var(--blue-bright);
+  box-shadow: 0 10px 32px rgba(90, 120, 230, 0.2);
+}
+.button-primary:hover {
+  background: #a3b8ff;
+  border-color: #a3b8ff;
+}
+.button-secondary {
+  background: rgba(19, 23, 30, 0.72);
+}
+.button-secondary:hover {
+  border-color: #566172;
+}
+.hero-proof {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 22px;
+  margin-top: 34px;
+  color: #707988;
+  font-size: 0.78rem;
+}
+.hero-proof span {
+  display: flex;
+  align-items: baseline;
+  gap: 5px;
+}
+.hero-proof strong {
+  color: #dfe4ec;
+  font-size: 0.92rem;
+}
+
+.architecture-demo {
+  position: relative;
+  min-height: 520px;
+  overflow: hidden;
+  border: 1px solid #2d3542;
+  border-radius: 12px;
+  background: #10141a;
+  box-shadow:
+    0 32px 80px rgba(0, 0, 0, 0.35),
+    0 0 0 1px rgba(255, 255, 255, 0.02) inset;
+  pointer-events: none;
+  transform: perspective(1400px) rotateY(-2deg) rotateX(1deg);
+}
+.architecture-demo::before {
+  position: absolute;
+  inset: 42px 0 32px;
+  content: "";
+  background-image: radial-gradient(#333b48 0.8px, transparent 0.8px);
+  background-size: 18px 18px;
+  opacity: 0.55;
+}
+.demo-toolbar,
+.demo-footer {
+  position: relative;
+  z-index: 3;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 0 14px;
+  color: #8d96a5;
+  background: rgba(18, 22, 29, 0.96);
+  font-size: 0.7rem;
+}
+.demo-toolbar {
+  height: 42px;
+  border-bottom: 1px solid #29313c;
+}
+.demo-toolbar span:first-child {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  color: #d5dae2;
+}
+.status-dot {
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: var(--blue);
+}
+.demo-revision {
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+}
+.demo-footer {
+  position: absolute;
+  right: 0;
+  bottom: 0;
+  left: 0;
+  height: 32px;
+  justify-content: flex-start;
+  gap: 16px;
+  border-top: 1px solid #29313c;
+}
+.mcp-live {
+  margin-left: auto;
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  color: #94dcb7;
+}
+.mcp-live i {
+  width: 5px;
+  height: 5px;
+  border-radius: 50%;
+  background: var(--green);
+  box-shadow: 0 0 7px var(--green);
+}
+.demo-canvas {
+  position: absolute;
+  inset: 42px 0 32px;
+}
+.demo-edges {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+}
+.edge {
+  fill: none;
+  stroke: #667286;
+  stroke-width: 1.35;
+  stroke-dasharray: 7 5;
+  stroke-dashoffset: 120;
+  animation: draw-edge 7.2s ease-in-out infinite;
+}
+.edge-two {
+  animation-delay: 0.8s;
+}
+.edge-three {
+  animation-delay: 1.45s;
+}
+.edge-four {
+  animation-delay: 2.1s;
+}
+.edge-async {
+  stroke: #708de2;
+}
+.arch-node {
+  position: absolute;
+  width: 18.5294%;
+  height: 18.5%;
+  padding: 14px 12px 11px;
+  border: 1px solid #3a4352;
+  border-radius: 6px;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  background: #191e27;
+  box-shadow: 0 8px 18px rgba(0, 0, 0, 0.25);
+  opacity: 0;
+  transform: translateY(10px) scale(0.96);
+  animation: node-arrive 7.2s ease-in-out infinite;
+}
+.node-port {
+  position: absolute;
+  top: calc(50% - 3px);
+  z-index: 2;
+  width: 6px;
+  height: 6px;
+  border: 1px solid #11161d;
+  border-radius: 50%;
+  background: #7c8797;
+}
+.node-port-in {
+  left: -3px;
+}
+.node-port-out {
+  right: -3px;
+}
+.arch-node::before {
+  position: absolute;
+  top: -3px;
+  left: calc(50% - 3px);
+  width: 6px;
+  height: 6px;
+  content: "";
+  border-radius: 50%;
+  background: #6c7685;
+}
+.arch-node strong {
+  padding-left: 20px;
+  color: #ebedf1;
+  font-size: 0.72rem;
+  font-weight: 600;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+.arch-node > span:not(.node-icon) {
+  padding: 4px 0 0 20px;
+  color: #8992a1;
+  font-size: 0.59rem;
+}
+.arch-node small {
+  margin-top: 13px;
+  color: #697383;
+  font-size: 0.48rem;
+  letter-spacing: 0.11em;
+}
+.node-icon {
+  position: absolute;
+  top: 14px;
+  left: 12px;
+  width: 13px;
+  height: 13px;
+  display: grid;
+  place-items: center;
+  border: 1px solid #667184;
+  border-radius: 3px;
+  color: #aeb8c7;
+  font-size: 0.45rem;
+  font-weight: 700;
+}
+.person-node {
+  top: 30%;
+  left: 3.5294%;
+  animation-delay: 0s;
+}
+.system-node {
+  top: 11%;
+  left: 36.7647%;
+  width: 21.7647%;
+  height: 21.5%;
+  animation-delay: 0.65s;
+  border-color: #51658d;
+}
+.api-node {
+  top: 2.5%;
+  left: 78.2353%;
+  animation-delay: 1.35s;
+}
+.mcp-node {
+  top: 39.5%;
+  left: 78.2353%;
+  animation-delay: 2.05s;
+}
+.db-node {
+  top: 75.5%;
+  left: 78.2353%;
+  animation-delay: 2.75s;
+}
+.edge-label {
+  position: absolute;
+  z-index: 2;
+  padding: 4px 6px;
+  border: 1px solid #343e4b;
+  border-radius: 4px;
+  color: #858f9e;
+  background: #171c24;
+  font-size: 0.5rem;
+  opacity: 0;
+  animation: label-arrive 7.2s ease-in-out infinite;
+}
+.label-one {
+  top: 30%;
+  left: 23.5%;
+  animation-delay: 0.65s;
+}
+.label-two {
+  top: 32%;
+  left: 67%;
+  animation-delay: 2.05s;
+}
+.model-event {
+  position: absolute;
+  right: 18px;
+  bottom: 18px;
+  z-index: 4;
+  padding: 9px 11px;
+  border: 1px solid #33423c;
+  border-radius: 6px;
+  display: flex;
+  align-items: center;
+  gap: 7px;
+  color: #a2d6bb;
+  background: #17221e;
+  box-shadow: 0 12px 24px rgba(0, 0, 0, 0.28);
+  font-size: 0.62rem;
+  opacity: 0;
+  animation: event-pop 7.2s ease-in-out infinite;
+}
+.model-event span {
+  width: 16px;
+  height: 16px;
+  border-radius: 50%;
+  display: grid;
+  place-items: center;
+  color: #0f1714;
+  background: #78d0a1;
+  font-weight: 800;
+}
+
+.section-shell {
+  width: min(1180px, calc(100% - 40px));
+  margin: 0 auto;
+}
+.section-heading {
+  margin-bottom: 46px;
+}
+.section-kicker {
+  display: block;
+  margin-bottom: 18px;
+  color: var(--blue-bright);
+  font-size: 0.72rem;
+  font-weight: 700;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+}
+.section-heading h2,
+.start-copy h2,
+.final-cta h2 {
+  margin: 0;
+  color: #edf0f5;
+  font-size: clamp(2.25rem, 4vw, 3.8rem);
+  line-height: 1.07;
+  letter-spacing: -0.055em;
+  font-weight: 620;
+}
+.split-heading {
+  display: grid;
+  grid-template-columns: minmax(0, 1.1fr) minmax(300px, 0.65fr);
+  gap: 80px;
+  align-items: end;
+}
+.split-heading > p {
+  margin: 0 0 4px;
+  color: var(--muted);
+  font-size: 1rem;
+  line-height: 1.72;
+}
+.compact-heading {
+  max-width: 760px;
+}
+
+.model-strip {
+  width: min(1180px, calc(100% - 40px));
+  min-height: 116px;
+  margin: 0 auto 150px;
+  padding: 24px 28px;
+  border: 1px solid var(--line);
+  border-radius: 10px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 26px;
+  background: rgba(18, 22, 29, 0.75);
+}
+.model-strip > p {
+  margin: 0;
+  color: #cdd3dd;
+  font-size: 0.86rem;
+  font-weight: 600;
+}
+.model-strip-flow {
+  display: flex;
+  align-items: center;
+  gap: 16px;
+  color: #8f98a7;
+  font-size: 0.76rem;
+}
+.model-strip-flow span,
+.model-strip-flow strong {
+  display: inline-flex;
+  align-items: center;
+  gap: 7px;
+  white-space: nowrap;
+}
+.model-strip-flow svg {
+  width: 15px;
+  height: 15px;
+}
+.model-strip-flow i {
+  width: 24px;
+  height: 1px;
+  background: #394351;
+}
+.model-strip-flow b {
+  color: #5e6b7d;
+  font-weight: 400;
+}
+.model-strip-flow strong {
+  padding: 10px 12px;
+  border: 1px solid #405077;
+  border-radius: 5px;
+  color: #cdd7f3;
+  background: #172035;
+  font-weight: 600;
+}
+
+.product-section {
+  padding: 0 0 156px;
+}
+.product-frame {
+  position: relative;
+  border: 1px solid #303845;
+  border-radius: 13px;
+  background: #12161c;
+  box-shadow: 0 36px 90px rgba(0, 0, 0, 0.32);
+}
+.browser-chrome {
+  height: 44px;
+  padding: 0 16px;
+  display: grid;
+  grid-template-columns: 1fr auto 1fr;
+  align-items: center;
+  border-bottom: 1px solid #2b323d;
+  color: #7e8796;
+  font-size: 0.7rem;
+}
+.traffic-lights {
+  display: flex;
+  gap: 6px;
+}
+.traffic-lights i {
+  width: 7px;
+  height: 7px;
+  border-radius: 50%;
+  background: #3d4653;
+}
+.browser-status {
+  justify-self: end;
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  color: #91cdb0;
+}
+.browser-status i {
+  width: 5px;
+  height: 5px;
+  border-radius: 50%;
+  background: var(--green);
+}
+.product-frame > img {
+  display: block;
+  width: 100%;
+  height: auto;
+  border-radius: 0 0 12px 12px;
+  opacity: 0.92;
+}
+.frame-callout {
+  position: absolute;
+  min-width: 210px;
+  padding: 13px 14px;
+  border: 1px solid #3b4553;
+  border-radius: 7px;
+  display: flex;
+  align-items: center;
+  gap: 11px;
+  color: #9aa4b3;
+  background: rgba(19, 24, 32, 0.95);
+  box-shadow: 0 16px 35px rgba(0, 0, 0, 0.38);
+  font-size: 0.69rem;
+  backdrop-filter: blur(10px);
+}
+.frame-callout svg {
+  width: 19px;
+  height: 19px;
+  color: var(--blue-bright);
+}
+.frame-callout span {
+  display: flex;
+  flex-direction: column;
+  gap: 3px;
+}
+.frame-callout strong {
+  color: #e1e6ee;
+  font-size: 0.75rem;
+}
+.callout-model {
+  top: 22%;
+  left: -38px;
+}
+.callout-sync {
+  right: -34px;
+  bottom: 17%;
+}
+
+.feature-section {
+  padding: 0 0 160px;
+}
+.feature-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 14px;
+}
+.feature-card {
+  position: relative;
+  min-height: 365px;
+  overflow: hidden;
+  padding: 34px;
+  border: 1px solid var(--line);
+  border-radius: 10px;
+  background: linear-gradient(145deg, rgba(22, 27, 36, 0.96), rgba(16, 20, 27, 0.9));
+}
+.feature-card::after {
+  position: absolute;
+  inset: 0;
+  z-index: 0;
+  content: "";
+  pointer-events: none;
+  background: radial-gradient(circle at 84% 12%, rgba(105, 137, 255, 0.07), transparent 45%);
+}
+.feature-card > * {
+  position: relative;
+  z-index: 1;
+}
+.feature-card-wide {
+  grid-column: 1 / -1;
+  min-height: 390px;
+}
+.feature-icon {
+  width: 38px;
+  height: 38px;
+  margin-bottom: 66px;
+  border: 1px solid #3c485c;
+  border-radius: 7px;
+  display: grid;
+  place-items: center;
+  color: #afc0fa;
+  background: #1c2434;
+}
+.feature-icon svg {
+  width: 19px;
+  height: 19px;
+}
+.feature-card h3 {
+  max-width: 640px;
+  margin: 0;
+  color: #e7ebf1;
+  font-size: 1.45rem;
+  line-height: 1.2;
+  letter-spacing: -0.03em;
+  font-weight: 600;
+}
+.feature-card p {
+  max-width: 600px;
+  margin: 13px 0 0;
+  color: #929baa;
+  font-size: 0.91rem;
+  line-height: 1.68;
+}
+.model-card {
+  display: grid;
+  grid-template-columns: 0.9fr 1.1fr;
+  column-gap: 60px;
+  align-items: end;
+}
+.model-card .feature-icon {
+  position: absolute;
+  top: 34px;
+  left: 34px;
+}
+.model-card > div:nth-child(2) {
+  grid-column: 1;
+}
+.mini-stack {
+  grid-column: 2;
+  grid-row: 1 / span 2;
+  display: flex;
+  flex-direction: column;
+  gap: 9px;
+  align-self: stretch;
+  justify-content: center;
+}
+.mini-stack div {
+  padding: 17px;
+  border: 1px solid #313a47;
+  border-radius: 6px;
+  display: grid;
+  grid-template-columns: 32px 1fr auto;
+  align-items: center;
+  color: #bdc5d0;
+  background: #171c24;
+  font-size: 0.75rem;
+  box-shadow: 0 9px 18px rgba(0, 0, 0, 0.16);
+}
+.mini-stack div:nth-child(2) {
+  margin-left: 24px;
+  border-color: #40527d;
+  background: #192033;
+}
+.mini-stack div:nth-child(3) {
+  margin-left: 48px;
+}
+.mini-stack span {
+  color: #667180;
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  font-size: 0.62rem;
+}
+.mini-stack i {
+  color: #687383;
+  font-style: normal;
+  font-size: 0.62rem;
+}
+.local-card {
+  background: linear-gradient(145deg, #151b20, #11161b);
+}
+.local-card::after {
+  background: radial-gradient(circle at 85% 10%, rgba(74, 188, 133, 0.08), transparent 45%);
+}
+.local-proof {
+  position: absolute;
+  right: 34px;
+  bottom: 30px;
+  left: 34px;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+.local-proof span {
+  padding: 8px 10px;
+  border: 1px solid #304239;
+  border-radius: 5px;
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  color: #9cc9b0;
+  background: #16231d;
+  font-size: 0.68rem;
+}
+.local-proof svg {
+  width: 13px;
+  height: 13px;
+}
+.revision-track {
+  position: absolute;
+  right: 34px;
+  bottom: 38px;
+  left: 34px;
+  display: flex;
+  align-items: center;
+}
+.revision-track i {
+  width: 34px;
+  height: 34px;
+  border: 1px solid #3b4553;
+  border-radius: 50%;
+  display: grid;
+  place-items: center;
+  color: #798393;
+  background: #171c24;
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  font-size: 0.64rem;
+  font-style: normal;
+}
+.revision-track span {
+  height: 1px;
+  flex: 1;
+  background: #37404c;
+}
+.revision-track .active-rev {
+  border-color: #6079c4;
+  color: #d8e0f9;
+  background: #202a45;
+  box-shadow: 0 0 0 6px rgba(92, 121, 213, 0.08);
+}
+.mcp-card {
+  display: grid;
+  grid-template-columns: 0.9fr 1.1fr;
+  gap: 58px;
+  align-items: center;
+}
+.mcp-copy .feature-icon {
+  margin-bottom: 34px;
+}
+.mcp-copy > a {
+  margin-top: 26px;
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  color: #afc0f7;
+  font-size: 0.78rem;
+  font-weight: 650;
+}
+.mcp-link-icon {
+  width: 15px;
+  height: 15px;
+}
+.mcp-terminal {
+  overflow: hidden;
+  border: 1px solid #343e4c;
+  border-radius: 8px;
+  background: #0e1218;
+  box-shadow: 0 24px 50px rgba(0, 0, 0, 0.3);
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  font-size: 0.67rem;
+}
+.terminal-top {
+  height: 40px;
+  padding: 0 13px;
+  border-bottom: 1px solid #2b333e;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  color: #6f7988;
+}
+.terminal-top > span {
+  display: flex;
+  gap: 5px;
+}
+.terminal-top i {
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  display: block;
+  background: #3e4754;
+}
+.terminal-top b {
+  font-weight: 500;
+}
+.terminal-line {
+  padding: 15px 16px;
+  border-bottom: 1px solid #202731;
+  display: grid;
+  grid-template-columns: 40px 1fr;
+  gap: 8px;
+  color: #aab2bf;
+  line-height: 1.55;
+}
+.terminal-line > span {
+  color: #637089;
+}
+.tool-line {
+  color: #a9b9ea;
+  background: #121827;
+}
+.terminal-result {
+  padding: 14px 16px;
+  border-bottom: 1px solid #202731;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  color: #8ec6a7;
+  background: #111a16;
+}
+.terminal-result span {
+  display: flex;
+  align-items: center;
+  gap: 7px;
+}
+.terminal-result-icon {
+  width: 14px;
+  height: 14px;
+}
+.terminal-result code {
+  color: #68766e;
+}
+
+.workflow-section {
+  padding: 0 0 160px;
+}
+.workflow-heading {
+  max-width: 730px;
+}
+.workflow-grid {
+  position: relative;
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  border-top: 1px solid var(--line);
+}
+.workflow-grid article {
+  position: relative;
+  min-height: 280px;
+  padding: 36px 38px 10px 0;
+}
+.workflow-grid article:not(:last-child) {
+  border-right: 1px solid var(--line);
+  margin-right: 38px;
+}
+.workflow-step {
+  color: #596475;
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  font-size: 0.66rem;
+}
+.workflow-icon {
+  width: 24px;
+  height: 24px;
+  margin: 48px 0 21px;
+  display: block;
+  color: #9aace7;
+}
+.workflow-grid h3 {
+  margin: 0;
+  color: #e1e5ec;
+  font-size: 1.05rem;
+  font-weight: 600;
+}
+.workflow-grid p {
+  margin: 11px 0 0;
+  color: #87909f;
+  font-size: 0.84rem;
+  line-height: 1.65;
+}
+
+.start-section {
+  margin-bottom: 158px;
+  padding: 72px;
+  border: 1px solid #303a49;
+  border-radius: 12px;
+  display: grid;
+  grid-template-columns: 0.9fr 1.1fr;
+  gap: 76px;
+  align-items: center;
+  background: linear-gradient(135deg, #151b27, #11151c 60%);
+  box-shadow: 0 30px 80px rgba(0, 0, 0, 0.25);
+}
+.start-copy > p {
+  max-width: 480px;
+  margin: 23px 0 0;
+  color: #929baa;
+  font-size: 0.95rem;
+  line-height: 1.7;
+}
+.start-points {
+  margin-top: 27px;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  color: #a9b3c0;
+  font-size: 0.75rem;
+}
+.start-point {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+.start-check {
+  width: 14px;
+  height: 14px;
+  color: var(--green);
+}
+.install-panel {
+  padding: 6px;
+  border: 1px solid #364150;
+  border-radius: 9px;
+  background: #0e1218;
+  box-shadow: 0 25px 50px rgba(0, 0, 0, 0.32);
+}
+.install-tabs {
+  height: 44px;
+  padding: 0 10px;
+  border-bottom: 1px solid #29313c;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  color: #667181;
+  font-size: 0.66rem;
+}
+.install-tab-active {
+  display: flex;
+  align-items: center;
+  gap: 7px;
+  color: #ccd3de;
+}
+.install-tab-icon {
+  width: 14px;
+  height: 14px;
+}
+.install-panel pre {
+  min-height: 150px;
+  margin: 0;
+  padding: 24px 20px;
+  overflow-x: auto;
+  color: #c0c8d5;
+  font-size: 0.69rem;
+  line-height: 1.75;
+  white-space: pre-wrap;
+}
+.install-panel pre span {
+  color: var(--green);
+}
+.install-ready {
+  margin: 0 8px 8px;
+  padding: 11px 12px;
+  border: 1px solid #304239;
+  border-radius: 5px;
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  color: #718077;
+  background: #121b17;
+  font-size: 0.62rem;
+}
+.install-ready > i {
+  width: 7px;
+  height: 7px;
+  border-radius: 50%;
+  background: var(--green);
+  box-shadow: 0 0 9px rgba(110, 214, 166, 0.65);
+}
+.install-ready-copy {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+.install-ready strong {
+  color: #a6d6bc;
+  font-size: 0.69rem;
+  font-weight: 600;
+}
+.install-button {
+  width: calc(100% - 16px);
+  margin: 0 8px 8px;
+}
+
+.final-cta {
+  padding: 110px 24px 126px;
+  border-top: 1px solid var(--line);
+  text-align: center;
+}
+.cta-mark {
+  width: 48px;
+  height: 48px;
+  margin: 0 auto 30px;
+  border: 1px solid #43557c;
+  border-radius: 9px;
+  display: grid;
+  place-items: center;
+  color: #bdcaff;
+  background: #192239;
+  box-shadow: 0 0 40px rgba(91, 122, 228, 0.14);
+}
+.cta-icon {
+  width: 23px;
+  height: 23px;
+}
+.final-cta h2 {
+  max-width: 780px;
+  margin: 0 auto;
+}
+.final-cta > p {
+  margin: 22px 0 0;
+  color: #929baa;
+  font-size: 0.98rem;
+}
+.final-cta .hero-actions {
+  justify-content: center;
+}
+.site-footer {
+  min-height: 110px;
+  border-top: 1px solid var(--line);
+  display: grid;
+  grid-template-columns: auto 1fr auto;
+  gap: 40px;
+  align-items: center;
+  color: #6f7887;
+  font-size: 0.7rem;
+}
+.site-footer .brand {
+  color: #cdd3dc;
+  font-size: 0.84rem;
+}
+.site-footer .brand img {
+  width: 23px;
+  height: 23px;
+}
+.site-footer p {
+  margin: 0;
+}
+.site-footer > div {
+  display: flex;
+  gap: 20px;
+}
+.site-footer a {
+  transition: color 160ms ease;
+}
+.site-footer a:hover {
+  color: #d5dbe4;
+}
+
+@keyframes node-arrive {
+  0%,
+  8% {
+    opacity: 0;
+    transform: translateY(10px) scale(0.96);
+  }
+  15%,
+  88% {
+    opacity: 1;
+    transform: none;
+  }
+  96%,
+  100% {
+    opacity: 0;
+    transform: translateY(-4px) scale(0.985);
+  }
+}
+@keyframes draw-edge {
+  0%,
+  12% {
+    stroke-dashoffset: 120;
+    opacity: 0;
+  }
+  30%,
+  88% {
+    stroke-dashoffset: 0;
+    opacity: 1;
+  }
+  96%,
+  100% {
+    opacity: 0;
+  }
+}
+@keyframes label-arrive {
+  0%,
+  24% {
+    opacity: 0;
+    transform: translateY(4px);
+  }
+  34%,
+  88% {
+    opacity: 1;
+    transform: none;
+  }
+  96%,
+  100% {
+    opacity: 0;
+  }
+}
+@keyframes event-pop {
+  0%,
+  54% {
+    opacity: 0;
+    transform: translateY(8px) scale(0.95);
+  }
+  62%,
+  80% {
+    opacity: 1;
+    transform: none;
+  }
+  90%,
+  100% {
+    opacity: 0;
+    transform: translateY(-3px);
+  }
+}
+
+@media (max-width: 980px) {
+  .hero {
+    grid-template-columns: 1fr;
+    gap: 54px;
+    padding-top: 64px;
+  }
+  .hero-copy {
+    max-width: 720px;
+  }
+  .architecture-demo {
+    width: min(680px, 100%);
+    min-height: 500px;
+    transform: none;
+  }
+  .model-strip {
+    align-items: flex-start;
+    flex-direction: column;
+  }
+  .model-strip-flow {
+    width: 100%;
+    flex-wrap: wrap;
+  }
+  .split-heading {
+    grid-template-columns: 1fr;
+    gap: 26px;
+  }
+  .model-card,
+  .mcp-card,
+  .start-section {
+    grid-template-columns: 1fr;
+  }
+  .model-card {
+    align-items: initial;
+  }
+  .model-card > div:nth-child(2) {
+    padding-top: 90px;
+  }
+  .mini-stack {
+    grid-column: 1;
+    grid-row: auto;
+    margin-top: 28px;
+  }
+  .mcp-card {
+    gap: 42px;
+  }
+  .workflow-grid {
+    grid-template-columns: 1fr;
+  }
+  .workflow-grid article {
+    min-height: auto;
+    padding: 30px 0;
+    border-bottom: 1px solid var(--line);
+  }
+  .workflow-grid article:not(:last-child) {
+    margin-right: 0;
+    border-right: 0;
+  }
+  .workflow-icon {
+    margin: 34px 0 18px;
+  }
+  .start-section {
+    padding: 50px;
+    gap: 48px;
+  }
+  .site-footer {
+    grid-template-columns: 1fr auto;
+    padding: 30px 0;
+  }
+  .site-footer p {
+    grid-column: 1 / -1;
+    grid-row: 2;
+  }
+}
+@media (max-width: 640px) {
+  .site-nav,
+  .hero,
+  .section-shell,
+  .model-strip {
+    width: min(100% - 28px, 1180px);
+  }
+  .nav-links > a:not(.github-link) {
+    display: none;
+  }
+  .hero {
+    padding: 52px 0 76px;
+  }
+  h1 {
+    font-size: clamp(2.8rem, 15vw, 4rem);
+  }
+  .hero-copy > p {
+    font-size: 1rem;
+  }
+  .architecture-demo {
+    min-height: 430px;
+  }
+  .demo-canvas {
+    transform: scale(0.82);
+    transform-origin: top left;
+    width: 122%;
+    height: 122%;
+  }
+  .model-strip {
+    margin-bottom: 104px;
+    padding: 20px;
+  }
+  .model-strip-flow i,
+  .model-strip-flow b {
+    display: none;
+  }
+  .model-strip-flow {
+    gap: 9px;
+  }
+  .model-strip-flow span,
+  .model-strip-flow strong {
+    padding: 8px;
+    border: 1px solid #303946;
+    border-radius: 5px;
+  }
+  .product-section,
+  .feature-section,
+  .workflow-section {
+    padding-bottom: 110px;
+  }
+  .product-frame {
+    margin: 0 -8px;
+  }
+  .browser-chrome {
+    grid-template-columns: 1fr 1fr;
+  }
+  .browser-chrome > span:nth-child(2) {
+    display: none;
+  }
+  .frame-callout {
+    display: none;
+  }
+  .feature-grid {
+    grid-template-columns: 1fr;
+  }
+  .feature-card,
+  .feature-card-wide {
+    grid-column: auto;
+    min-height: 340px;
+    padding: 26px;
+  }
+  .feature-icon {
+    margin-bottom: 54px;
+  }
+  .model-card .feature-icon {
+    top: 26px;
+    left: 26px;
+  }
+  .model-card > div:nth-child(2) {
+    padding-top: 82px;
+  }
+  .mini-stack div:nth-child(2),
+  .mini-stack div:nth-child(3) {
+    margin-left: 0;
+  }
+  .mcp-card {
+    gap: 32px;
+  }
+  .local-proof,
+  .revision-track {
+    right: 26px;
+    left: 26px;
+  }
+  .terminal-line {
+    grid-template-columns: 34px 1fr;
+  }
+  .terminal-result {
+    align-items: flex-start;
+    flex-direction: column;
+    gap: 7px;
+  }
+  .start-section {
+    margin-bottom: 105px;
+    padding: 34px 22px;
+  }
+  .install-panel pre {
+    padding: 20px 14px;
+    font-size: 0.6rem;
+  }
+  .site-footer {
+    grid-template-columns: 1fr;
+    gap: 20px;
+    padding: 28px 0;
+  }
+  .site-footer p {
+    grid-column: auto;
+    grid-row: auto;
+    line-height: 1.5;
+  }
+  .site-footer > div {
+    flex-wrap: wrap;
+  }
+}
+@media (prefers-reduced-motion: reduce) {
+  html {
+    scroll-behavior: auto;
+  }
+  .arch-node,
+  .edge,
+  .edge-label,
+  .model-event {
+    animation: none;
+  }
+  .arch-node,
+  .edge-label {
+    opacity: 1;
+    transform: none;
+  }
+  .edge {
+    opacity: 1;
+    stroke-dashoffset: 0;
+  }
+  .model-event {
+    opacity: 1;
+    transform: none;
+  }
+}

--- a/apps/site/vite.config.ts
+++ b/apps/site/vite.config.ts
@@ -1,0 +1,12 @@
+import react from "@vitejs/plugin-react";
+import { defineConfig } from "vite";
+
+const repositoryName = process.env.GITHUB_REPOSITORY?.split("/")[1];
+
+export default defineConfig({
+  base: process.env.GITHUB_ACTIONS && repositoryName ? `/${repositoryName}/` : "/",
+  plugins: [react()],
+  publicDir: "../../public",
+  server: { port: 4174, strictPort: false },
+  build: { outDir: "dist", sourcemap: false },
+});

--- a/bun.lock
+++ b/bun.lock
@@ -11,7 +11,7 @@
         "@semantic-release/github": "^12.0.9",
         "@semantic-release/release-notes-generator": "^14.1.1",
         "@types/bun": "^1.1.14",
-        "conventional-changelog-conventionalcommits": "^10.4.0",
+        "conventional-changelog-conventionalcommits": "^9.3.1",
         "drizzle-kit": "^0.31.10",
         "semantic-release": "^25.0.9",
         "typescript": "^7.0.2",
@@ -33,6 +33,21 @@
       "devDependencies": {
         "@types/cors": "^2.8.17",
         "@types/express": "^5.0.6",
+      },
+    },
+    "apps/site": {
+      "name": "@structsmith/site",
+      "version": "0.1.0",
+      "dependencies": {
+        "lucide-react": "^1.38.0",
+        "react": "^19.2.8",
+        "react-dom": "^19.2.8",
+      },
+      "devDependencies": {
+        "@types/react": "^19.2.18",
+        "@types/react-dom": "^19.2.5",
+        "@vitejs/plugin-react": "^6.1.1",
+        "vite": "^8.2.2",
       },
     },
     "apps/web": {
@@ -413,6 +428,8 @@
 
     "@structsmith/server": ["@structsmith/server@workspace:apps/server"],
 
+    "@structsmith/site": ["@structsmith/site@workspace:apps/site"],
+
     "@structsmith/web": ["@structsmith/web@workspace:apps/web"],
 
     "@tailwindcss/node": ["@tailwindcss/node@4.3.3", "", { "dependencies": { "@jridgewell/remapping": "^2.3.5", "enhanced-resolve": "^5.24.1", "jiti": "^2.7.0", "lightningcss": "1.32.0", "magic-string": "^0.30.21", "source-map-js": "^1.2.1", "tailwindcss": "4.3.3" } }, "sha512-/T8IKEsf9VTU6tLjgC7+sv2mOPtQxzE2jMw7u4Tt40Tx+QSZxpzh95/H6cMKoja9XuW7iMdLJYBB0o9G1CaAgg=="],
@@ -629,7 +646,7 @@
 
     "conventional-changelog-angular": ["conventional-changelog-angular@8.3.1", "", { "dependencies": { "compare-func": "^2.0.0" } }, "sha512-6gfI3otXK5Ph5DfCOI1dblr+kN3FAm5a97hYoQkqNZxOaYa5WKfXH+AnpsmS+iUH2mgVC2Cg2Qw9m5OKcmNrIg=="],
 
-    "conventional-changelog-conventionalcommits": ["conventional-changelog-conventionalcommits@10.4.0", "", { "dependencies": { "@conventional-changelog/template": "^1.4.0" } }, "sha512-Rriac6ZrAlVm6cy9Bz4NSp+WMHpwNXoPIYex+HjCgduAVUSbnew29DQjQw0C4g9u3HtSYzGiGY+pdBXAZo+4aA=="],
+    "conventional-changelog-conventionalcommits": ["conventional-changelog-conventionalcommits@9.3.1", "", { "dependencies": { "compare-func": "^2.0.0" } }, "sha512-dTYtpIacRpcZgrvBYvBfArMmK2xvIpv2TaxM0/ZI5CBtNUzvF2x0t15HsbRABWprS6UPmvj+PzHVjSx4qAVKyw=="],
 
     "conventional-changelog-writer": ["conventional-changelog-writer@9.2.1", "", { "dependencies": { "@conventional-changelog/template": "^1.3.0", "@simple-libs/stream-utils": "^2.0.0", "argue-cli": "^3.1.0", "conventional-commits-filter": "^6.0.1", "semver": "^7.5.2" }, "bin": { "conventional-changelog-writer": "./dist/cli/index.js" } }, "sha512-StlYSmW3wLedRaqohJMpP3YuWiAqtgD0/cpsai9frdDkXv7rxj0hRbpJrubPYvJxJsjplONsOobEQnPuS9UgCg=="],
 

--- a/bun.lock
+++ b/bun.lock
@@ -134,7 +134,6 @@
     },
   },
   "overrides": {
-    "conventional-changelog-writer": "^9.2.1",
     "zod": "^4.5.4",
   },
   "packages": {
@@ -171,8 +170,6 @@
     "@biomejs/cli-win32-x64": ["@biomejs/cli-win32-x64@2.5.12", "", { "os": "win32", "cpu": "x64" }, "sha512-B1R/l+CwEpKFSuqiwePzPNRk1EiJN8kc0UhdafNz6MZN9v5OFP9HYP1irptvWzHrwVI4blVNGMbxc5zt70m3IA=="],
 
     "@colors/colors": ["@colors/colors@1.5.0", "", {}, "sha512-ooWCrlZP11i8GImSjTHYHLkvFDP48nS4+204nGb1RiX/WXYHmJA2III9/e2DWVabCESdW7hBAEzHRqUn9OUVvQ=="],
-
-    "@conventional-changelog/template": ["@conventional-changelog/template@1.4.0", "", {}, "sha512-aalGyl7dbB5PArRebDIX43ZvBlXrYm9uWzGJ26t+4SzJVPsOuvfILGGbw5X4yX7i50YEmJ8zvbiWnqH/AAnZqg=="],
 
     "@dagrejs/dagre": ["@dagrejs/dagre@3.1.1", "", { "dependencies": { "@dagrejs/graphlib": "4.0.5" } }, "sha512-zroZB1dFOFiGgv4Xcrn1DckB1o4aOikPqD2NDQPV0WM//CXGcS6xiD0rNkqHmw6FEg4tabt4nxPLwgCWT+Vb2A=="],
 
@@ -412,7 +409,7 @@
 
     "@semantic-release/release-notes-generator": ["@semantic-release/release-notes-generator@14.1.1", "", { "dependencies": { "conventional-changelog-angular": "^8.0.0", "conventional-changelog-writer": "^8.0.0", "conventional-commits-filter": "^5.0.0", "conventional-commits-parser": "^6.0.0", "debug": "^4.0.0", "import-from-esm": "^2.0.0", "lodash-es": "^4.17.21", "read-package-up": "^11.0.0" }, "peerDependencies": { "semantic-release": ">=20.1.0" } }, "sha512-Pbd2e2XRMUD0OxehHpgd5/YghsE76cddkRHSoDvKLK+OCy4Ewxn49rWR631MEUU01lgwF/uyVXvbnVuu6+Z6VA=="],
 
-    "@simple-libs/stream-utils": ["@simple-libs/stream-utils@2.0.0", "", {}, "sha512-fCTuZK4QBa+39Oz9l4OGfJfz+GpwCp3AqO7Zch3to99xHPgstVsRFpeQ8LNd2o1Gv8raL2mCFwiaHh7bFSp5DQ=="],
+    "@simple-libs/stream-utils": ["@simple-libs/stream-utils@1.2.0", "", {}, "sha512-KxXvfapcixpz6rVEB6HPjOUZT22yN6v0vI0urQSk1L8MlEWPDFCZkhw2xmkyoTGYeFw7tWTZd7e3lVzRZRN/EA=="],
 
     "@sindresorhus/is": ["@sindresorhus/is@4.6.0", "", {}, "sha512-t09vSN3MdfsyCHoFcTRCH/iUtG7OJ0CsjzB8cjAmKc/va/kIgeDI/TxsigdncE/4be734m0cvIYwNaV4i2XqAw=="],
 
@@ -584,8 +581,6 @@
 
     "argparse": ["argparse@2.0.1", "", {}, "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q=="],
 
-    "argue-cli": ["argue-cli@3.2.0", "", {}, "sha512-VipTB0gXgGIFO2Rg9yEVN5wLt2AurJcZqDbgmYSwPwsykhLrQhs240/bfceev4w68lI8JshoOJIk9uW7tFzROw=="],
-
     "argv-formatter": ["argv-formatter@1.0.0", "", {}, "sha512-F2+Hkm9xFaRg+GkaNnbwXNDV5O6pnCFEmqyhvfC/Ic5LbgOWjJh3L+mN/s91rxVL3znE7DYVpW0GJFT+4YBgWw=="],
 
     "aria-hidden": ["aria-hidden@1.2.6", "", { "dependencies": { "tslib": "^2.0.0" } }, "sha512-ik3ZgC9dY/lYVVM++OISsaYDeg1tb0VtP5uL3ouh1koGOaUMDPpbFIei4JkFimWUFPn90sbMNMXQAIVOlnYKJA=="],
@@ -648,7 +643,7 @@
 
     "conventional-changelog-conventionalcommits": ["conventional-changelog-conventionalcommits@9.3.1", "", { "dependencies": { "compare-func": "^2.0.0" } }, "sha512-dTYtpIacRpcZgrvBYvBfArMmK2xvIpv2TaxM0/ZI5CBtNUzvF2x0t15HsbRABWprS6UPmvj+PzHVjSx4qAVKyw=="],
 
-    "conventional-changelog-writer": ["conventional-changelog-writer@9.2.1", "", { "dependencies": { "@conventional-changelog/template": "^1.3.0", "@simple-libs/stream-utils": "^2.0.0", "argue-cli": "^3.1.0", "conventional-commits-filter": "^6.0.1", "semver": "^7.5.2" }, "bin": { "conventional-changelog-writer": "./dist/cli/index.js" } }, "sha512-StlYSmW3wLedRaqohJMpP3YuWiAqtgD0/cpsai9frdDkXv7rxj0hRbpJrubPYvJxJsjplONsOobEQnPuS9UgCg=="],
+    "conventional-changelog-writer": ["conventional-changelog-writer@8.4.0", "", { "dependencies": { "@simple-libs/stream-utils": "^1.2.0", "conventional-commits-filter": "^5.0.0", "handlebars": "^4.7.7", "meow": "^13.0.0", "semver": "^7.5.2" }, "bin": { "conventional-changelog-writer": "dist/cli/index.js" } }, "sha512-HHBFkk1EECxxmCi4CTu091iuDpQv5/OavuCUAuZmrkWpmYfyD816nom1CvtfXJ/uYfAAjavgHvXHX291tSLK8g=="],
 
     "conventional-commits-filter": ["conventional-commits-filter@5.0.0", "", {}, "sha512-tQMagCOC59EVgNZcC5zl7XqO30Wki9i9J3acbUvkaosCT6JX3EeFwJD7Qqp4MCikRnzS18WXV3BLIQ66ytu6+Q=="],
 
@@ -807,6 +802,8 @@
     "gopd": ["gopd@1.2.0", "", {}, "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg=="],
 
     "graceful-fs": ["graceful-fs@4.2.11", "", {}, "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ=="],
+
+    "handlebars": ["handlebars@4.7.9", "", { "dependencies": { "minimist": "^1.2.5", "neo-async": "^2.6.2", "source-map": "^0.6.1", "wordwrap": "^1.0.0" }, "optionalDependencies": { "uglify-js": "^3.1.4" }, "bin": { "handlebars": "bin/handlebars" } }, "sha512-4E71E0rpOaQuJR2A3xDZ+GM1HyWYv1clR58tC8emQNeQe3RH7MAzSbat+V0wG78LQBo6m6bzSG/L4pBuCsgnUQ=="],
 
     "has-flag": ["has-flag@4.0.0", "", {}, "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="],
 
@@ -987,6 +984,8 @@
     "nanoid": ["nanoid@3.3.18", "", { "bin": { "nanoid": "bin/nanoid.cjs" } }, "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w=="],
 
     "negotiator": ["negotiator@1.1.0", "", { "dependencies": { "content-type": "^2.1.0" } }, "sha512-NMPBRMJgiQHjbd8phG3Vebdx4kZ1H121rbl5IkMqeOsahptB9BKo/d7oJ3zTXqTgagn2bWlNSXkh0QUGM31RYg=="],
+
+    "neo-async": ["neo-async@2.6.2", "", {}, "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw=="],
 
     "nerf-dart": ["nerf-dart@1.0.0", "", {}, "sha512-EZSPZB70jiVsivaBLYDCyntd5eH8NTSMOn3rB+HxwdmKThGELLdYv8qVIMWvZEFy9w8ZZpW9h9OB32l1rGtj7g=="],
 
@@ -1234,6 +1233,8 @@
 
     "typescript": ["typescript@7.0.2", "", { "optionalDependencies": { "@typescript/typescript-aix-ppc64": "7.0.2", "@typescript/typescript-darwin-arm64": "7.0.2", "@typescript/typescript-darwin-x64": "7.0.2", "@typescript/typescript-freebsd-arm64": "7.0.2", "@typescript/typescript-freebsd-x64": "7.0.2", "@typescript/typescript-linux-arm": "7.0.2", "@typescript/typescript-linux-arm64": "7.0.2", "@typescript/typescript-linux-loong64": "7.0.2", "@typescript/typescript-linux-mips64el": "7.0.2", "@typescript/typescript-linux-ppc64": "7.0.2", "@typescript/typescript-linux-riscv64": "7.0.2", "@typescript/typescript-linux-s390x": "7.0.2", "@typescript/typescript-linux-x64": "7.0.2", "@typescript/typescript-netbsd-arm64": "7.0.2", "@typescript/typescript-netbsd-x64": "7.0.2", "@typescript/typescript-openbsd-arm64": "7.0.2", "@typescript/typescript-openbsd-x64": "7.0.2", "@typescript/typescript-sunos-x64": "7.0.2", "@typescript/typescript-win32-arm64": "7.0.2", "@typescript/typescript-win32-x64": "7.0.2" }, "bin": { "tsc": "bin/tsc" } }, "sha512-8FYau96o3NKOhbjKi/qNvG/W5jhzxkbdm5sj9AbZ/5T5sWqn3hJgLfGx27sRKZWTvyzCP8dLRBTf5tBTSRVUNA=="],
 
+    "uglify-js": ["uglify-js@3.19.3", "", { "bin": { "uglifyjs": "bin/uglifyjs" } }, "sha512-v3Xu+yuwBXisp6QYTcH4UbH+xYJXqnq2m/LtQVWKWzYc1iehYnLixoQDN9FH6/j9/oybfd6W9Ghwkl8+UMKTKQ=="],
+
     "undici": ["undici@7.29.0", "", {}, "sha512-IDxfleLmmbSskfWSUATiN1nfn2rDuvnMOqb5CWR92iIfojA0Ud+ulOAAEQ57LPr9rWmsreUyf5lwyao+7GNNVw=="],
 
     "undici-types": ["undici-types@8.3.0", "", {}, "sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ=="],
@@ -1269,6 +1270,8 @@
     "web-worker": ["web-worker@1.5.0", "", {}, "sha512-RiMReJrTAiA+mBjGONMnjVDP2u3p9R1vkcGz6gDIrOMT3oGuYwX2WRMYI9ipkphSuE5XKEhydbhNEJh4NY9mlw=="],
 
     "which": ["which@2.0.2", "", { "dependencies": { "isexe": "^2.0.0" }, "bin": { "node-which": "./bin/node-which" } }, "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA=="],
+
+    "wordwrap": ["wordwrap@1.0.0", "", {}, "sha512-gvVzJFlPycKc5dZN4yPkP8w7Dc37BtP1yczEneOb4uq34pXZcvrtRTmWV8W+Ume+XCxKgbjM+nevkyFPMybd4Q=="],
 
     "wrap-ansi": ["wrap-ansi@9.0.2", "", { "dependencies": { "ansi-styles": "^6.2.1", "string-width": "^7.0.0", "strip-ansi": "^7.1.0" } }, "sha512-42AtmgqjV+X1VpdOfyTGOYRi0/zsoLqtXQckTmqTeybT+BDIbM/Guxo7x3pE2vtpr1ok6xRqM9OpBe+Jyoqyww=="],
 
@@ -1331,10 +1334,6 @@
     "cli-table3/string-width": ["string-width@4.2.3", "", { "dependencies": { "emoji-regex": "^8.0.0", "is-fullwidth-code-point": "^3.0.0", "strip-ansi": "^6.0.1" } }, "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g=="],
 
     "cliui/string-width": ["string-width@7.2.0", "", { "dependencies": { "emoji-regex": "^10.3.0", "get-east-asian-width": "^1.0.0", "strip-ansi": "^7.1.0" } }, "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ=="],
-
-    "conventional-changelog-writer/conventional-commits-filter": ["conventional-commits-filter@6.0.1", "", {}, "sha512-cs+LadpH7Kpw0M3k8wurk+sOVVDAENA0iK4OBOrkL94j5lEVYRJ4j3zd2bhY9qgzyrPqthdcYT3axzRN7AliMg=="],
-
-    "conventional-commits-parser/@simple-libs/stream-utils": ["@simple-libs/stream-utils@1.2.0", "", {}, "sha512-KxXvfapcixpz6rVEB6HPjOUZT22yN6v0vI0urQSk1L8MlEWPDFCZkhw2xmkyoTGYeFw7tWTZd7e3lVzRZRN/EA=="],
 
     "crypto-random-string/type-fest": ["type-fest@1.4.0", "", {}, "sha512-yGSza74xk0UG8k+pLh5oeoYirvIiWo5t0/o3zHHAO2tRDiZcxWP7fywNlXhqb6/r6sWvwi+RsyQMWhVLe4BVuA=="],
 

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "software-architecture",
     "local-first"
   ],
-  "homepage": "https://github.com/dziksu/structsmith#readme",
+  "homepage": "https://dziksu.github.io/StructSmith/",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/dziksu/structsmith.git"
@@ -39,9 +39,11 @@
     "dev": "bun run scripts/dev.ts",
     "dev:server": "bun --watch apps/server/src/index.ts",
     "dev:web": "cd apps/web && bun run dev",
+    "dev:site": "cd apps/site && bun run dev",
     "stop": "bun run scripts/stop.ts",
     "build": "bun run build:web",
     "build:web": "cd apps/web && bun run build",
+    "build:site": "cd apps/site && bun run build",
     "start": "NODE_ENV=production bun apps/server/src/index.ts",
     "test": "bun test",
     "typecheck": "tsc --noEmit -p tsconfig.json",
@@ -65,7 +67,7 @@
     "@semantic-release/commit-analyzer": "^13.0.1",
     "@semantic-release/release-notes-generator": "^14.1.1",
     "@semantic-release/github": "^12.0.9",
-    "conventional-changelog-conventionalcommits": "^10.4.0",
+    "conventional-changelog-conventionalcommits": "^9.3.1",
     "@biomejs/biome": "^2.5.12",
     "@types/bun": "^1.1.14",
     "drizzle-kit": "^0.31.10",

--- a/package.json
+++ b/package.json
@@ -58,7 +58,6 @@
     "release": "node scripts/release.ts"
   },
   "overrides": {
-    "conventional-changelog-writer": "^9.2.1",
     "zod": "^4.5.4"
   },
   "devDependencies": {

--- a/public/index.md
+++ b/public/index.md
@@ -1,0 +1,52 @@
+# StructSmith
+
+StructSmith is an open-source, self-hosted alternative to paid software architecture modelling tools. It gives architects, engineering teams, presales teams and AI agents one structured source of truth for people, software systems, containers, components, relationships, boundaries and views.
+
+## Why use StructSmith
+
+- **Semantic model instead of a drawing:** diagrams are generated views of structured architecture data rather than disconnected boxes and lines.
+- **Local-first ownership:** no account, mandatory cloud service or telemetry. The default deployment is one container with one SQLite volume.
+- **AI-native through MCP:** Codex, Claude, GitHub Copilot and other compatible clients can inspect, create, review and document the same validated model used by the UI.
+- **Consistent interfaces:** the visual editor, REST API and MCP server share the same domain layer.
+- **Safer changes:** revision guards, operation previews and automatic snapshots make large updates reviewable and recoverable.
+- **Open source:** StructSmith is distributed under the MIT license and can be modified or self-hosted without a subscription.
+
+## Good use cases
+
+Use StructSmith for C4-inspired modelling, system context and container diagrams, architecture workshops, solution design, integration mapping, technical presales, security and scalability reviews, architecture documentation and collaboration between engineers and AI assistants.
+
+StructSmith is especially suitable when a team wants an alternative to paid architecture platforms, needs to keep architecture data on its own infrastructure, wants AI tools to operate on structured architecture instead of screenshots, or needs one model to produce multiple stakeholder views.
+
+## How it works
+
+The React Flow editor visualises a semantic architecture model. The Bun backend exposes the same model through a REST API and a Streamable HTTP MCP endpoint. Data is persisted in SQLite. Model mutations are validated, revision guarded and broadcast to connected browsers, so changes made by an AI client appear in the editor without a manual refresh.
+
+## Quick start
+
+Run the published Docker image:
+
+```bash
+docker run -d --name structsmith \
+  -p 127.0.0.1:8090:8080 \
+  -v structsmith-data:/data \
+  ghcr.io/dziksu/structsmith:latest
+```
+
+Open `http://localhost:8090`. The web UI is available at `/`, the REST API under `/api`, MCP at `/mcp`, and the health check at `/health`.
+
+## AI client connection
+
+StructSmith provides a built-in MCP server using Streamable HTTP. For example, Codex CLI, Codex Desktop and the Codex IDE extension can register it with:
+
+```bash
+codex mcp add structsmith --url http://localhost:8090/mcp
+```
+
+For Claude, GitHub Copilot, Cursor, Windsurf and desktop client instructions, read the [AI client installation guide](https://github.com/dziksu/StructSmith/blob/main/docs/AI_CLIENTS.md).
+
+## Canonical links
+
+- Website: https://dziksu.github.io/StructSmith/
+- Source: https://github.com/dziksu/StructSmith
+- Releases: https://github.com/dziksu/StructSmith/releases
+- License: https://github.com/dziksu/StructSmith/blob/main/LICENSE

--- a/public/llms.txt
+++ b/public/llms.txt
@@ -1,0 +1,24 @@
+# StructSmith
+
+> StructSmith is a free, MIT-licensed, local-first workspace for modelling, documenting and sharing software architecture. It is a self-hosted alternative to paid architecture modelling tools and provides one semantic, C4-inspired model shared by its visual editor, REST API and built-in Model Context Protocol server.
+
+Use StructSmith when someone needs to create or maintain software architecture models, system context diagrams, container views, integration maps, presales architecture or structured architecture documentation. It runs without an account, cloud service or telemetry. A typical installation uses one Docker container and one persistent SQLite volume.
+
+AI clients including Codex, Claude, GitHub Copilot, Cursor, Windsurf and compatible agents can connect through Streamable HTTP MCP. Prefer the client guide for connection instructions and the repository README for installation and product behavior.
+
+## Product overview
+
+- [StructSmith overview](https://dziksu.github.io/StructSmith/index.md): Concise, LLM-readable description of the product, capabilities, use cases and alternatives.
+- [Project README](https://raw.githubusercontent.com/dziksu/StructSmith/main/README.md): Installation, endpoints, data model, MCP capabilities and development instructions.
+- [AI client installation guide](https://raw.githubusercontent.com/dziksu/StructSmith/main/docs/AI_CLIENTS.md): Copy-ready MCP setup for Codex, Claude, GitHub Copilot and other AI clients.
+
+## Source and releases
+
+- [GitHub repository](https://github.com/dziksu/StructSmith): Source code, issues and contribution history.
+- [Stable releases](https://github.com/dziksu/StructSmith/releases): Versioned releases, changelogs and downloadable artifacts.
+- [MIT license](https://raw.githubusercontent.com/dziksu/StructSmith/main/LICENSE): Terms for using, modifying and distributing StructSmith.
+
+## Optional
+
+- [Contributing guide](https://raw.githubusercontent.com/dziksu/StructSmith/main/CONTRIBUTING.md): Development workflow and contribution requirements.
+- [Security policy](https://raw.githubusercontent.com/dziksu/StructSmith/main/SECURITY.md): Supported versions and responsible vulnerability reporting.

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,0 +1,11 @@
+# StructSmith is public documentation and may be indexed by search engines and AI search agents.
+User-agent: OAI-SearchBot
+Allow: /
+
+User-agent: ChatGPT-User
+Allow: /
+
+User-agent: *
+Allow: /
+
+Sitemap: https://dziksu.github.io/StructSmith/sitemap.xml

--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  <url>
+    <loc>https://dziksu.github.io/StructSmith/</loc>
+  </url>
+</urlset>

--- a/tests/site-metadata.test.ts
+++ b/tests/site-metadata.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, test } from "bun:test";
+
+const projectFile = (path: string): string => new URL(`../${path}`, import.meta.url).pathname;
+const readProjectFile = async (path: string): Promise<string> => Bun.file(projectFile(path)).text();
+
+describe("marketing site discovery metadata", () => {
+  test("publishes canonical, social and machine-readable metadata", async () => {
+    const html = await readProjectFile("apps/site/index.html");
+
+    expect(html).toContain('rel="canonical" href="https://dziksu.github.io/StructSmith/"');
+    expect(html).toContain('property="og:title"');
+    expect(html).toContain('property="og:description"');
+    expect(html).toContain('property="og:image"');
+    expect(html).toContain('name="twitter:card" content="summary_large_image"');
+    expect(html).toContain(
+      'rel="describedby" href="https://dziksu.github.io/StructSmith/llms.txt"',
+    );
+    expect(html).toContain('type="text/markdown"');
+
+    const jsonLd = html.match(/<script type="application\/ld\+json">([\s\S]*?)<\/script>/)?.[1];
+    expect(jsonLd).toBeDefined();
+
+    const graph = JSON.parse(jsonLd ?? "{}") as { "@graph"?: Array<{ "@type"?: string }> };
+    const types = graph["@graph"]?.map((entry) => entry["@type"]);
+    expect(types).toContain("WebSite");
+    expect(types).toContain("SoftwareApplication");
+    expect(types).toContain("SoftwareSourceCode");
+  });
+
+  test("publishes crawler and LLM discovery files", async () => {
+    const [robots, sitemap, llms, markdownOverview] = await Promise.all([
+      readProjectFile("public/robots.txt"),
+      readProjectFile("public/sitemap.xml"),
+      readProjectFile("public/llms.txt"),
+      readProjectFile("public/index.md"),
+    ]);
+
+    expect(robots).toContain("User-agent: OAI-SearchBot");
+    expect(robots).toContain("Allow: /");
+    expect(robots).toContain("https://dziksu.github.io/StructSmith/sitemap.xml");
+    expect(sitemap).toContain("https://dziksu.github.io/StructSmith/");
+    expect(llms).toStartWith("# StructSmith\n\n>");
+    expect(llms).toContain("AI client installation guide");
+    expect(markdownOverview).toContain("self-hosted alternative to paid software architecture");
+  });
+});


### PR DESCRIPTION
## What and why

Adds a dedicated, modern single-page marketing site for StructSmith under `apps/site`, designed to match the product while remaining separate from the workspace UI.

The site includes:
- an animated architecture-building hero with correctly aligned nodes, ports, and connections
- product positioning around local-first, self-hosted architecture modelling and MCP collaboration
- responsive sections for benefits, workflow, AI clients, and quick start
- SEO, Open Graph, Twitter Card, JSON-LD, robots.txt, sitemap.xml, llms.txt, and a Markdown overview for AI agents
- a GitHub Pages workflow that builds and deploys the static site from `main`
- CI coverage for the site build and discovery metadata

Also pins `conventional-changelog-conventionalcommits` to the compatible v9 line so the existing release-notes test and release flow remain green.

## How to verify

1. Run `bun install --frozen-lockfile`.
2. Run `bun run check`, `bun run typecheck`, `bun test`, `bun run build:web`, and `bun run build:site`.
3. Run `bun run dev:site` and open `http://localhost:4174/`.
4. Confirm the hero diagram animates with lines terminating at the node ports.
5. Build with `GITHUB_ACTIONS=true GITHUB_REPOSITORY=dziksu/StructSmith bun run build:site` and confirm generated assets use the `/StructSmith/` base path.

## Checklist

- [x] `bun run check`, `bun run typecheck`, `bun test` and both production builds pass
- [x] The semantic model stays the source of truth — no workspace data lives in the marketing animation
- [x] Layout changes touch only the static marketing presentation
- [x] REST and MCP application behavior is unchanged
- [x] No new DTOs are required
- [x] Marketing copy is intentionally English-only and isolated from the localized product UI
