### PR TITLE
fix(ci): enable Pages on first deployment

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -39,6 +39,8 @@ jobs:
 
       - name: Configure GitHub Pages
         uses: actions/configure-pages@v6
+        with:
+          enablement: true
 
       - name: Upload site artifact
         uses: actions/upload-pages-artifact@v5

--- a/README.md
+++ b/README.md
@@ -92,8 +92,8 @@ bun run dev:site
 
 `bun run build:site` creates the GitHub Pages artifact in `apps/site/dist`. Changes to the
 site, shared public assets, or its workflow are published automatically from `main` by the
-`GitHub Pages` action. Before the first deployment, select **GitHub Actions** as the source in
-the repository's **Settings → Pages**; later pushes need no manual publishing step.
+`GitHub Pages` action. The workflow enables Pages on its first run, so publishing does not
+require a manual repository setting.
 
 ---
 


### PR DESCRIPTION
## Closed

The repository owner enabled **GitHub Actions** as the Pages publishing source in repository settings, which is the supported setup for this workflow.

This automatic enablement attempt is no longer needed. It would also require a token with administration and Pages write permissions rather than the default `GITHUB_TOKEN`.