### PR TITLE
docs(changelog): update for v1.6.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [1.6.2](https://github.com/dziksu/structsmith/compare/v1.6.1...v1.6.2) (2026-09-08)
+
+### Bug Fixes
+
+* **ui:** improve dark theme ownership cues ([#42](https://github.com/dziksu/structsmith/issues/42)) ([db7f16e](https://github.com/dziksu/structsmith/commit/db7f16ed975c0f0a7c85b5bc4c1a45f781a3ba27))
+
 ## [1.6.1](https://github.com/dziksu/structsmith/compare/v1.6.0...v1.6.1) (2026-09-07)
 
 ### Bug Fixes

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "structsmith",
   "private": true,
-  "version": "1.6.1",
+  "version": "1.6.2",
   "license": "MIT",
   "description": "Local-first, MCP-native tool for modelling software architecture — a self-hosted alternative to Structurizr with a React Flow editor.",
   "keywords": [


### PR DESCRIPTION
Automated release metadata update generated by semantic-release.

Release: v1.6.2
Updates: CHANGELOG.md and the application version in package.json