### PR TITLE
fix(ci): merge ready release metadata pull requests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -131,11 +131,26 @@ jobs:
             Release: v${{ steps.release.outputs.version }}
             Updates: CHANGELOG.md and the application version in package.json
 
-      - name: Enable changelog pull request auto-merge
+      - name: Merge release metadata pull request
         if: steps.changelog-pr.outputs.pull-request-number != ''
-        run: gh pr merge --squash --auto "${{ steps.changelog-pr.outputs.pull-request-number }}"
         env:
           GH_TOKEN: ${{ secrets.RELEASE_PR_TOKEN }}
+          RELEASE_PR_NUMBER: ${{ steps.changelog-pr.outputs.pull-request-number }}
+        run: |
+          merge_state="$(gh pr view "$RELEASE_PR_NUMBER" --json mergeStateStatus --jq '.mergeStateStatus')"
+          if [ "$merge_state" = "CLEAN" ]; then
+            gh pr merge --squash "$RELEASE_PR_NUMBER"
+          elif ! gh pr merge --squash --auto "$RELEASE_PR_NUMBER"; then
+            # The PR can become immediately mergeable between the status read
+            # and the auto-merge request. GitHub rejects auto-merge in that state.
+            merge_state="$(gh pr view "$RELEASE_PR_NUMBER" --json mergeStateStatus --jq '.mergeStateStatus')"
+            if [ "$merge_state" = "CLEAN" ]; then
+              gh pr merge --squash "$RELEASE_PR_NUMBER"
+            else
+              echo "Could not merge release metadata PR; merge state is $merge_state"
+              exit 1
+            fi
+          fi
 
   publish:
     name: Publish release image

--- a/tests/boundaries.test.ts
+++ b/tests/boundaries.test.ts
@@ -142,6 +142,10 @@ describe("semantic boundaries", () => {
       );
 
       const document = services.model.getDocument(workspace.id);
+      const productionId = result.appliedOperations.find(
+        (operation) => operation.ref === "production",
+      )?.id;
+      expect(productionId).toBeDefined();
       expect(document.views[0]?.boundaries).toHaveLength(2);
       expect(toMermaid(document, { view: document.views[0] })).toContain("subgraph");
       expect(toMermaid(document, { view: document.views[0] })).toContain(
@@ -149,7 +153,7 @@ describe("semantic boundaries", () => {
       );
 
       const withBoundaries = services.snapshots.create(workspace.id, "With view boundaries");
-      services.boundaries.delete(workspace.id, document.views[0]?.boundaries[0]?.id as string, {
+      services.boundaries.delete(workspace.id, productionId as string, {
         cascade: true,
       });
       expect(services.views.get(document.views[0]?.id as string).boundaries).toEqual([]);

--- a/tests/release.test.js
+++ b/tests/release.test.js
@@ -26,7 +26,9 @@ test("release syncs changelog and package version through one auto-merged pull r
   const stamp = `bun scripts/set-build-version.ts "\${{ steps.release.outputs.version }}"`;
   expect(workflow).toContain("id: changelog-pr");
   expect(workflow).toContain("steps.changelog-pr.outputs.pull-request-number != ''");
-  expect(workflow).toContain("gh pr merge --squash --auto");
+  expect(workflow).toContain('if [ "$merge_state" = "CLEAN" ]; then');
+  expect(workflow).toContain('gh pr merge --squash "$RELEASE_PR_NUMBER"');
+  expect(workflow).toContain('gh pr merge --squash --auto "$RELEASE_PR_NUMBER"');
   expect(workflow).toContain("GH_TOKEN:");
   expect(workflow).toContain("secrets.RELEASE_PR_TOKEN");
   expect(workflow).toContain(stamp);


### PR DESCRIPTION
The semantic release job failed after creating PR #47 because GitHub rejects `gh pr merge --auto` when the pull request is already immediately mergeable (`CLEAN`). The workflow now merges a clean release metadata PR directly, enables auto-merge when requirements are still pending, and rechecks for the same state transition if GitHub changes the merge state between those operations.

The boundary snapshot test also now deletes the root boundary by its operation reference instead of relying on nondeterministic same-timestamp ordering.

## How to verify

- `bun test ./tests/release.test.js`
- `bun test` (63 tests)
- Repeated boundary suite: 8/8 passes
- `bun run check`
- `bun run typecheck`
- `bun run build`
- Workflow YAML parses successfully