### PR TITLE
docs(changelog): update for v1.8.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [1.8.1](https://github.com/dziksu/structsmith/compare/v1.8.0...v1.8.1) (2026-09-09)
+
+### Bug Fixes
+
+* **ci:** merge ready release metadata pull requests ([#48](https://github.com/dziksu/structsmith/issues/48)) ([901b081](https://github.com/dziksu/structsmith/commit/901b08105dc57fc3f46c50b3d4872d4107c44d62))
+
 ## [1.8.0](https://github.com/dziksu/structsmith/compare/v1.7.0...v1.8.0) (2026-09-09)
 
 ### Features

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "structsmith",
   "private": true,
-  "version": "1.8.0",
+  "version": "1.8.1",
   "license": "MIT",
   "description": "Local-first, MCP-native tool for modelling software architecture — a self-hosted alternative to Structurizr with a React Flow editor.",
   "keywords": [


### PR DESCRIPTION
Automated release metadata update generated by semantic-release.

Release: v1.8.1
Updates: CHANGELOG.md and the application version in package.json