### PR TITLE
fix(ci): keep cache failures from breaking release metadata

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,6 +46,7 @@ jobs:
 
   docker:
     name: Docker image builds
+    if: ${{ github.event_name != 'pull_request' || !startsWith(github.head_ref, 'automation/changelog-v') }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
@@ -132,6 +133,28 @@ jobs:
 
             Release: v${{ steps.release.outputs.version }}
             Updates: CHANGELOG.md and the application version in package.json
+
+      - name: Wait for release metadata verification
+        if: steps.changelog-pr.outputs.pull-request-number != ''
+        env:
+          GH_TOKEN: ${{ secrets.RELEASE_PR_TOKEN }}
+          RELEASE_PR_NUMBER: ${{ steps.changelog-pr.outputs.pull-request-number }}
+        run: |
+          for attempt in $(seq 1 120); do
+            check_bucket="$(
+              gh pr checks "$RELEASE_PR_NUMBER" \
+                --json name,bucket \
+                --jq '.[] | select(.name == "Lint, types, tests, build") | .bucket' \
+                2>/dev/null || true
+            )"
+            case "$check_bucket" in
+              pass|skipping) exit 0 ;;
+              fail|cancel) echo "Release metadata verification failed"; exit 1 ;;
+            esac
+            sleep 5
+          done
+          echo "Timed out waiting for release metadata verification"
+          exit 1
 
       - name: Merge release metadata pull request
         if: steps.changelog-pr.outputs.pull-request-number != ''

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,8 +59,10 @@ jobs:
           push: false
           load: true
           tags: structsmith:ci
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+          cache-from: type=gha,scope=ci
+          # Cache uploads are an optimization. A full or temporarily
+          # unavailable GitHub cache must not fail an otherwise valid build.
+          cache-to: type=gha,mode=min,scope=ci,ignore-error=true,timeout=2m
 
       - name: Smoke test the image
         run: |

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -58,5 +58,7 @@ jobs:
             APP_VERSION=${{ inputs.version }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+          cache-from: type=gha,scope=release-image
+          # Publishing the image is authoritative; exporting its build cache
+          # is best-effort and must not turn a successful push into a failure.
+          cache-to: type=gha,mode=max,scope=release-image,ignore-error=true,timeout=2m

--- a/tests/release.test.js
+++ b/tests/release.test.js
@@ -36,6 +36,19 @@ test("release syncs changelog and package version through one auto-merged pull r
   expect(workflow.indexOf(stamp)).toBeLessThan(workflow.indexOf("id: changelog-pr"));
 });
 
+test("Docker cache export cannot block CI or image publication", () => {
+  const ciWorkflow = readFileSync(new URL("../.github/workflows/ci.yml", import.meta.url), "utf8");
+  const imageWorkflow = readFileSync(
+    new URL("../.github/workflows/docker.yml", import.meta.url),
+    "utf8",
+  );
+
+  expect(ciWorkflow).toContain("cache-to: type=gha,mode=min,scope=ci,ignore-error=true,timeout=2m");
+  expect(imageWorkflow).toContain(
+    "cache-to: type=gha,mode=max,scope=release-image,ignore-error=true,timeout=2m",
+  );
+});
+
 test("source package version matches the newest changelog release", () => {
   const manifest = JSON.parse(readFileSync(new URL("../package.json", import.meta.url), "utf8"));
   const changelog = readFileSync(new URL("../CHANGELOG.md", import.meta.url), "utf8");

--- a/tests/release.test.js
+++ b/tests/release.test.js
@@ -26,6 +26,11 @@ test("release syncs changelog and package version through one auto-merged pull r
   const stamp = `bun scripts/set-build-version.ts "\${{ steps.release.outputs.version }}"`;
   expect(workflow).toContain("id: changelog-pr");
   expect(workflow).toContain("steps.changelog-pr.outputs.pull-request-number != ''");
+  expect(workflow).toContain("Wait for release metadata verification");
+  expect(workflow).toContain('select(.name == "Lint, types, tests, build")');
+  expect(workflow.indexOf("Wait for release metadata verification")).toBeLessThan(
+    workflow.indexOf("Merge release metadata pull request"),
+  );
   expect(workflow).toContain('if [ "$merge_state" = "CLEAN" ]; then');
   expect(workflow).toContain('gh pr merge --squash "$RELEASE_PR_NUMBER"');
   expect(workflow).toContain('gh pr merge --squash --auto "$RELEASE_PR_NUMBER"');
@@ -44,6 +49,9 @@ test("Docker cache export cannot block CI or image publication", () => {
   );
 
   expect(ciWorkflow).toContain("cache-to: type=gha,mode=min,scope=ci,ignore-error=true,timeout=2m");
+  expect(ciWorkflow).toContain(
+    "github.event_name != 'pull_request' || !startsWith(github.head_ref, 'automation/changelog-v')",
+  );
   expect(imageWorkflow).toContain(
     "cache-to: type=gha,mode=max,scope=release-image,ignore-error=true,timeout=2m",
   );


### PR DESCRIPTION
## What and why

CI run #98 built the Docker image successfully, then failed while exporting the optional BuildKit cache with `failed to reserve cache`. Make cache uploads best-effort, reduce ordinary CI exports to `mode=min`, and isolate CI and release-image cache scopes.

Automated changelog PRs now skip the redundant Docker build. The release workflow waits for their `Lint, types, tests, build` check before merging, so a metadata PR cannot be merged while its validation is still pending or failing.

## How to verify

- `bun run check`
- `bun run typecheck`
- `bun run test` — 64 passing
- `bun run build`
- `bun run build:site`
- Confirm a normal PR Docker job completes even if the GitHub Actions cache exporter cannot reserve storage.
- Confirm an `automation/changelog-v*` PR skips Docker and is merged only after verification passes.

## Checklist

- [x] `bun run check`, `bun run typecheck`, `bun run test` and `bun run build` pass
- [x] The semantic model stays the source of truth — no data lives only in React Flow state
- [x] Layout changes touch views, not elements
- [x] REST and MCP still go through the same domain services
- [x] New DTOs are defined in `packages/contracts`
- [x] User-facing copy goes through i18n (`en` and `pl` locales updated)