### PR TITLE
feat: add diagram multi-selection and clipboard shortcuts

### DIFF
--- a/apps/web/src/features/canvas/Canvas.tsx
+++ b/apps/web/src/features/canvas/Canvas.tsx
@@ -532,11 +532,13 @@ export function Canvas({
   const onNodeContextMenu = useCallback<NodeMouseHandler>(
     (event, node) => {
       event.preventDefault();
-      if (node.type === "boundary" && node.data?.boundaryId) {
-        select({ type: "boundary", id: String(node.data.boundaryId) });
+      // Right-click and right-button panning must never activate a boundary.
+      // Boundaries remain selectable with an intentional left click.
+      if (node.type === "boundary") {
+        setMenu(null);
         return;
       }
-      const elementId = isBoundaryId(node.id) ? boundaryElementId(node.id) : node.id;
+      const elementId = node.id;
       select({ type: "element", id: elementId });
       setMenu({
         x: event.clientX,
@@ -841,9 +843,9 @@ export function Canvas({
           );
         }}
         onDelete={deleteSelection}
-        selectionOnDrag
         selectionMode={SelectionMode.Partial}
-        panOnDrag={[1, 2]}
+        panOnDrag
+        selectionKeyCode={primaryModifierKeyCode()}
         multiSelectionKeyCode={primaryModifierKeyCode()}
         // A selected boundary covers a large area. Keep the explicit graph
         // layering (boundaries < edges < elements) so cards remain clickable.

--- a/apps/web/src/features/canvas/Canvas.tsx
+++ b/apps/web/src/features/canvas/Canvas.tsx
@@ -19,6 +19,7 @@ import {
   type OnNodeDrag,
   type OnSelectionChangeParams,
   ReactFlow,
+  SelectionMode,
   useNodesInitialized,
   useReactFlow,
 } from "@xyflow/react";
@@ -27,11 +28,13 @@ import { useTranslation } from "react-i18next";
 import { toast } from "sonner";
 import { useApiErrorHandler, useApplyOperations } from "@/hooks/useApi";
 import { api } from "@/lib/api";
+import { hasPrimaryModifier, primaryModifierKeyCode } from "@/lib/platform";
 import { invalidateWorkspace } from "@/lib/query";
 import { useEditorStore } from "@/store/editor";
 import { useHistoryStore } from "@/store/history";
 import { useCopyAgentReference } from "../reference/useCopyAgentReference";
 import { BoundaryNode } from "./BoundaryNode";
+import { buildPasteOperations, createDiagramClipboard } from "./clipboard";
 import { ElementNode } from "./ElementNode";
 import {
   boundaryElementId,
@@ -90,6 +93,8 @@ export function Canvas({
   const focusRequest = useEditorStore((state) => state.focusRequest);
   const beginSave = useEditorStore((state) => state.beginSave);
   const endSave = useEditorStore((state) => state.endSave);
+  const clipboard = useEditorStore((state) => state.clipboard);
+  const setClipboard = useEditorStore((state) => state.setClipboard);
 
   const graph = useMemo(
     () => buildGraph({ view, elements, relationships, records }),
@@ -358,7 +363,12 @@ export function Canvas({
 
   const onSelectionChange = useCallback(
     ({ nodes: selectedNodes, edges: selectedEdges }: OnSelectionChangeParams) => {
-      const node = selectedNodes[0];
+      const elementNodes = selectedNodes.filter((node) => node.type === "element");
+      if (elementNodes.length > 1) {
+        select({ type: "elements", ids: elementNodes.map((node) => node.id).sort() });
+        return;
+      }
+      const node = elementNodes[0] ?? selectedNodes[0];
       const edge = selectedEdges[0];
       if (node) {
         if (node.type === "boundary" && node.data?.boundaryId) {
@@ -371,18 +381,28 @@ export function Canvas({
         }
       } else if (edge) {
         select({ type: "relationship", id: relationshipIdOf(edge) });
+      } else {
+        clearSelection();
       }
     },
-    [select],
+    [clearSelection, select],
   );
 
   const onNodeClick = useCallback<NodeMouseHandler>(
     (_event, node) => {
-      if (!connectFrom || isBoundaryId(node.id)) return;
+      if (node.type === "boundary") {
+        if (node.data?.boundaryId) {
+          select({ type: "boundary", id: String(node.data.boundaryId) });
+        } else if (node.data?.elementId) {
+          select({ type: "element", id: String(node.data.elementId) });
+        }
+        return;
+      }
+      if (!connectFrom) return;
       createRelationship(connectFrom, node.id);
       setConnectFrom(null);
     },
-    [connectFrom, createRelationship, setConnectFrom],
+    [connectFrom, createRelationship, select, setConnectFrom],
   );
 
   const removeFromView = useCallback(
@@ -418,6 +438,47 @@ export function Canvas({
       });
     },
     [applyOperations, t],
+  );
+
+  const deleteSelection = useCallback(
+    ({ nodes: deletedNodes, edges: deletedEdges }: { nodes: FlowNode[]; edges: FlowEdge[] }) => {
+      const elementIds = deletedNodes
+        .filter((node) => node.type === "element")
+        .map((node) => node.id);
+      // React Flow also reports edges connected to a deleted node. Only remove
+      // a semantic relationship when the edge itself was explicitly selected.
+      const relationshipIds = [
+        ...new Set(
+          deletedEdges
+            .filter((edge) => edge.selected)
+            .map(relationshipIdOf)
+            .filter((id) => !id.startsWith("implied:")),
+        ),
+      ];
+      if (elementIds.length === 0 && relationshipIds.length === 0) return;
+
+      applyOperations.mutate({
+        label: t("canvas.deletedSelection"),
+        operations: [
+          ...(elementIds.length > 0
+            ? [
+                {
+                  op: "setViewElements" as const,
+                  viewId: view.id,
+                  elementIds,
+                  mode: "remove" as const,
+                },
+              ]
+            : []),
+          ...relationshipIds.map((relationshipId) => ({
+            op: "deleteRelationship" as const,
+            relationshipId,
+          })),
+        ],
+      });
+      clearSelection();
+    },
+    [applyOperations, clearSelection, t, view.id],
   );
 
   const deleteFromModel = useCallback(
@@ -632,6 +693,77 @@ export function Canvas({
     [applyOperations, boundaries, flow, t, view.elements, view.id],
   );
 
+  /* ------------------------------- shortcuts ------------------------------- */
+
+  useEffect(() => {
+    const onKeyDown = (event: KeyboardEvent): void => {
+      const target = event.target as HTMLElement | null;
+      const typing =
+        target?.tagName === "INPUT" ||
+        target?.tagName === "TEXTAREA" ||
+        target?.isContentEditable === true;
+      if (typing || !hasPrimaryModifier(event)) return;
+
+      const key = event.key.toLowerCase();
+      if (key === "a") {
+        event.preventDefault();
+        const ids = nodes.filter((node) => node.type === "element").map((node) => node.id);
+        setNodes((current) =>
+          current.map((node) => ({ ...node, selected: node.type === "element" })),
+        );
+        setEdges((current) =>
+          current.map((edge) => (edge.selected ? { ...edge, selected: false } : edge)),
+        );
+        if (ids.length === 1) select({ type: "element", id: ids[0] as string });
+        else if (ids.length > 1) select({ type: "elements", ids: ids.sort() });
+        else clearSelection();
+        return;
+      }
+
+      if (key === "c") {
+        const ids = nodes
+          .filter((node) => node.type === "element" && node.selected)
+          .map((node) => node.id);
+        const nextClipboard = createDiagramClipboard(
+          workspaceId,
+          view,
+          elements,
+          relationships,
+          ids,
+        );
+        if (!nextClipboard) return;
+        event.preventDefault();
+        setClipboard(nextClipboard);
+        toast.success(t("canvas.copiedElements", { count: ids.length }));
+        return;
+      }
+
+      if (key === "v" && clipboard && !applyOperations.isPending) {
+        event.preventDefault();
+        applyOperations.mutate({
+          label: t("canvas.pastedElements", { count: clipboard.elements.length }),
+          operations: buildPasteOperations(clipboard, workspaceId, view.id),
+        });
+        setClipboard({ ...clipboard, pasteCount: clipboard.pasteCount + 1 });
+      }
+    };
+
+    window.addEventListener("keydown", onKeyDown);
+    return () => window.removeEventListener("keydown", onKeyDown);
+  }, [
+    applyOperations,
+    clearSelection,
+    clipboard,
+    elements,
+    nodes,
+    relationships,
+    select,
+    setClipboard,
+    t,
+    view,
+    workspaceId,
+  ]);
+
   /* --------------------------------- render --------------------------------- */
 
   const allNodes = useMemo(() => {
@@ -652,7 +784,9 @@ export function Canvas({
       view.settings.showBoundaries,
     ).map((boundary) => ({
       ...boundary,
-      selected: selection.type === "element" && selection.id === boundaryElementId(boundary.id),
+      selected:
+        (selection.type === "element" && selection.id === boundaryElementId(boundary.id)) ||
+        (selection.type === "elements" && selection.ids.includes(boundaryElementId(boundary.id))),
     }));
     const semanticBoundaries = computeSemanticBoundaries(
       sources,
@@ -706,12 +840,11 @@ export function Canvas({
             current.map((edge) => (edge.selected ? { ...edge, selected: false } : edge)),
           );
         }}
-        onNodesDelete={(deleted) => {
-          for (const node of deleted) {
-            if (!isBoundaryId(node.id)) removeFromView(node.id);
-          }
-        }}
-        onEdgesDelete={(deleted) => deleteRelationships(deleted.map(relationshipIdOf))}
+        onDelete={deleteSelection}
+        selectionOnDrag
+        selectionMode={SelectionMode.Partial}
+        panOnDrag={[1, 2]}
+        multiSelectionKeyCode={primaryModifierKeyCode()}
         snapToGrid={view.settings.snapToGrid}
         snapGrid={[16, 16]}
         minZoom={0.15}

--- a/apps/web/src/features/canvas/Canvas.tsx
+++ b/apps/web/src/features/canvas/Canvas.tsx
@@ -34,7 +34,7 @@ import { useEditorStore } from "@/store/editor";
 import { useHistoryStore } from "@/store/history";
 import { useCopyAgentReference } from "../reference/useCopyAgentReference";
 import { BoundaryNode } from "./BoundaryNode";
-import { buildPasteOperations, createDiagramClipboard } from "./clipboard";
+import { buildPasteOperations, createDiagramClipboard, type DiagramCopyMode } from "./clipboard";
 import { ElementNode } from "./ElementNode";
 import {
   boundaryElementId,
@@ -529,6 +529,24 @@ export function Canvas({
     [applyOperations, elementsById, view.elements, view.id],
   );
 
+  const copyElementsToClipboard = useCallback(
+    (elementIds: readonly string[], mode: DiagramCopyMode = "with-connections") => {
+      const nextClipboard = createDiagramClipboard(
+        workspaceId,
+        view,
+        elements,
+        relationships,
+        elementIds,
+        mode,
+      );
+      if (!nextClipboard) return false;
+      setClipboard(nextClipboard);
+      toast.success(t("canvas.copiedElements", { count: elementIds.length }));
+      return true;
+    },
+    [elements, relationships, setClipboard, t, view, workspaceId],
+  );
+
   const onNodeContextMenu = useCallback<NodeMouseHandler>(
     (event, node) => {
       event.preventDefault();
@@ -539,7 +557,20 @@ export function Canvas({
         return;
       }
       const elementId = node.id;
-      select({ type: "element", id: elementId });
+      const selectedElementIds = nodes
+        .filter((candidate) => candidate.type === "element" && candidate.selected)
+        .map((candidate) => candidate.id);
+      const contextElementIds =
+        node.selected && selectedElementIds.length > 1 ? selectedElementIds : [elementId];
+      if (!node.selected) {
+        setNodes((current) =>
+          current.map((candidate) => ({ ...candidate, selected: candidate.id === elementId })),
+        );
+        setEdges((current) =>
+          current.map((edge) => (edge.selected ? { ...edge, selected: false } : edge)),
+        );
+        select({ type: "element", id: elementId });
+      }
       setMenu({
         x: event.clientX,
         y: event.clientY,
@@ -549,7 +580,16 @@ export function Canvas({
             onSelect: () => select({ type: "element", id: elementId }),
           },
           {
+            label: t("contextMenu.copyWithConnections"),
+            onSelect: () => copyElementsToClipboard(contextElementIds),
+          },
+          {
+            label: t("contextMenu.copyElementsOnly"),
+            onSelect: () => copyElementsToClipboard(contextElementIds, "elements-only"),
+          },
+          {
             label: t("reference.copy"),
+            separatorBefore: true,
             onSelect: () =>
               void copyReference({
                 type: "element",
@@ -578,10 +618,12 @@ export function Canvas({
     },
     [
       copyReference,
+      copyElementsToClipboard,
       deleteFromModel,
       duplicateElement,
       elementsById,
       hideInView,
+      nodes,
       removeFromView,
       select,
       setConnectFrom,
@@ -726,17 +768,8 @@ export function Canvas({
         const ids = nodes
           .filter((node) => node.type === "element" && node.selected)
           .map((node) => node.id);
-        const nextClipboard = createDiagramClipboard(
-          workspaceId,
-          view,
-          elements,
-          relationships,
-          ids,
-        );
-        if (!nextClipboard) return;
+        if (!copyElementsToClipboard(ids)) return;
         event.preventDefault();
-        setClipboard(nextClipboard);
-        toast.success(t("canvas.copiedElements", { count: ids.length }));
         return;
       }
 
@@ -756,9 +789,8 @@ export function Canvas({
     applyOperations,
     clearSelection,
     clipboard,
-    elements,
+    copyElementsToClipboard,
     nodes,
-    relationships,
     select,
     setClipboard,
     t,

--- a/apps/web/src/features/canvas/Canvas.tsx
+++ b/apps/web/src/features/canvas/Canvas.tsx
@@ -845,6 +845,9 @@ export function Canvas({
         selectionMode={SelectionMode.Partial}
         panOnDrag={[1, 2]}
         multiSelectionKeyCode={primaryModifierKeyCode()}
+        // A selected boundary covers a large area. Keep the explicit graph
+        // layering (boundaries < edges < elements) so cards remain clickable.
+        elevateNodesOnSelect={false}
         snapToGrid={view.settings.snapToGrid}
         snapGrid={[16, 16]}
         minZoom={0.15}

--- a/apps/web/src/features/canvas/clipboard.test.ts
+++ b/apps/web/src/features/canvas/clipboard.test.ts
@@ -87,7 +87,7 @@ const view: ViewDetail = {
 };
 
 describe("diagram clipboard", () => {
-  test("copies only relationships internal to the selected group", () => {
+  test("copies incident relationships by default", () => {
     const externalRelationship = { ...relationship, id: "external", targetElementId: "three" };
     const clipboard = createDiagramClipboard(
       "workspace",
@@ -98,7 +98,21 @@ describe("diagram clipboard", () => {
     );
 
     expect(clipboard?.elements.map((item) => item.id)).toEqual(["one", "two"]);
-    expect(clipboard?.relationships.map((item) => item.id)).toEqual(["relationship"]);
+    expect(clipboard?.relationships.map((item) => item.id)).toEqual(["relationship", "external"]);
+  });
+
+  test("can copy elements without any relationships", () => {
+    const clipboard = createDiagramClipboard(
+      "workspace",
+      view,
+      [element("one"), element("two")],
+      [relationship],
+      ["one", "two"],
+      "elements-only",
+    );
+
+    expect(clipboard?.elements).toHaveLength(2);
+    expect(clipboard?.relationships).toEqual([]);
   });
 
   test("pastes elements, hierarchy, layout and internal relationships in one batch", () => {
@@ -135,6 +149,26 @@ describe("diagram clipboard", () => {
       data: {
         sourceElementId: "@copy-element-0",
         targetElementId: "@copy-element-1",
+      },
+    });
+  });
+
+  test("reconnects a copied element to an existing neighbour in the same workspace", () => {
+    const clipboard = createDiagramClipboard(
+      "workspace",
+      view,
+      [element("one"), element("two")],
+      [relationship],
+      ["one"],
+    );
+    if (!clipboard) throw new Error("Expected clipboard data");
+
+    const operations = buildPasteOperations(clipboard, "workspace", "view");
+    expect(operations.at(-1)).toMatchObject({
+      op: "createRelationship",
+      data: {
+        sourceElementId: "@copy-element-0",
+        targetElementId: "two",
       },
     });
   });

--- a/apps/web/src/features/canvas/clipboard.test.ts
+++ b/apps/web/src/features/canvas/clipboard.test.ts
@@ -1,0 +1,141 @@
+import { describe, expect, test } from "bun:test";
+import type {
+  ArchitectureElement,
+  ArchitectureRelationship,
+  ViewDetail,
+} from "@structsmith/contracts";
+import { buildPasteOperations, createDiagramClipboard } from "./clipboard";
+
+const timestamp = "2026-01-01T00:00:00.000Z";
+const element = (id: string, parentId: string | null = null): ArchitectureElement => ({
+  id,
+  workspaceId: "workspace",
+  parentId,
+  kind: "container",
+  role: null,
+  name: id,
+  description: null,
+  technology: null,
+  external: false,
+  tags: [],
+  properties: {},
+  createdAt: timestamp,
+  updatedAt: timestamp,
+});
+
+const relationship: ArchitectureRelationship = {
+  id: "relationship",
+  workspaceId: "workspace",
+  sourceElementId: "one",
+  targetElementId: "two",
+  description: "calls",
+  technology: "HTTP",
+  interactionStyle: "sync",
+  tags: [],
+  properties: {},
+  createdAt: timestamp,
+  updatedAt: timestamp,
+};
+
+const view: ViewDetail = {
+  id: "view",
+  workspaceId: "workspace",
+  key: "view",
+  name: "View",
+  description: null,
+  kind: "container",
+  scopeElementId: null,
+  settings: {
+    showBoundaries: true,
+    snapToGrid: false,
+    autoLayoutDirection: "LR",
+    autoLayoutAlgorithm: "dagre",
+    boundaryLayer: "deployment",
+    relationshipRouting: "orthogonal",
+    showRelationshipLabels: true,
+    showFullTitles: false,
+    showDescriptions: false,
+  },
+  createdAt: timestamp,
+  updatedAt: timestamp,
+  elements: [
+    {
+      viewId: "view",
+      elementId: "one",
+      x: 10,
+      y: 20,
+      width: null,
+      height: null,
+      hidden: false,
+      locked: false,
+      zIndex: 0,
+    },
+    {
+      viewId: "view",
+      elementId: "two",
+      x: 100,
+      y: 120,
+      width: null,
+      height: null,
+      hidden: false,
+      locked: false,
+      zIndex: 0,
+    },
+  ],
+  relationships: [],
+  boundaries: [],
+};
+
+describe("diagram clipboard", () => {
+  test("copies only relationships internal to the selected group", () => {
+    const externalRelationship = { ...relationship, id: "external", targetElementId: "three" };
+    const clipboard = createDiagramClipboard(
+      "workspace",
+      view,
+      [element("one"), element("two", "one"), element("three")],
+      [relationship, externalRelationship],
+      ["one", "two"],
+    );
+
+    expect(clipboard?.elements.map((item) => item.id)).toEqual(["one", "two"]);
+    expect(clipboard?.relationships.map((item) => item.id)).toEqual(["relationship"]);
+  });
+
+  test("pastes elements, hierarchy, layout and internal relationships in one batch", () => {
+    const clipboard = createDiagramClipboard(
+      "workspace",
+      view,
+      [element("one"), element("two", "one")],
+      [relationship],
+      ["one", "two"],
+    );
+    if (!clipboard) throw new Error("Expected clipboard data");
+
+    const operations = buildPasteOperations(clipboard, "workspace", "view");
+    expect(operations.map((operation) => operation.op)).toEqual([
+      "createElement",
+      "createElement",
+      "setViewElements",
+      "setLayout",
+      "createRelationship",
+    ]);
+    expect(operations[1]).toMatchObject({
+      op: "createElement",
+      data: { parentId: "@copy-element-0" },
+    });
+    expect(operations[3]).toMatchObject({
+      op: "setLayout",
+      entries: [
+        { elementId: "@copy-element-0", x: 50, y: 60 },
+        { elementId: "@copy-element-1", x: 140, y: 160 },
+      ],
+    });
+    expect(operations[4]).toMatchObject({
+      op: "createRelationship",
+      data: {
+        sourceElementId: "@copy-element-0",
+        targetElementId: "@copy-element-1",
+      },
+    });
+  });
+});

--- a/apps/web/src/features/canvas/clipboard.ts
+++ b/apps/web/src/features/canvas/clipboard.ts
@@ -1,0 +1,158 @@
+import type {
+  ArchitectureElement,
+  ArchitectureOperationInput,
+  ArchitectureRelationship,
+  ViewDetail,
+} from "@structsmith/contracts";
+import type { DiagramClipboard } from "@/store/editor";
+
+export function createDiagramClipboard(
+  workspaceId: string,
+  view: ViewDetail,
+  elements: readonly ArchitectureElement[],
+  relationships: readonly ArchitectureRelationship[],
+  selectedElementIds: readonly string[],
+): DiagramClipboard | null {
+  const selected = new Set(selectedElementIds);
+  const copiedElements = elements.filter((element) => selected.has(element.id));
+  if (copiedElements.length === 0) return null;
+
+  const copiedRelationships = relationships.filter(
+    (relationship) =>
+      selected.has(relationship.sourceElementId) && selected.has(relationship.targetElementId),
+  );
+  const copiedRelationshipIds = new Set(copiedRelationships.map((relationship) => relationship.id));
+
+  return {
+    workspaceId,
+    viewId: view.id,
+    elements: copiedElements,
+    relationships: copiedRelationships,
+    placements: view.elements.filter((placement) => selected.has(placement.elementId)),
+    relationshipPlacements: view.relationships.filter((placement) =>
+      copiedRelationshipIds.has(placement.relationshipId),
+    ),
+    boundaryMemberships: view.boundaries.flatMap((boundary) => {
+      const elementIds = boundary.elementIds.filter((elementId) => selected.has(elementId));
+      return elementIds.length > 0 ? [{ boundaryId: boundary.id, elementIds }] : [];
+    }),
+    pasteCount: 0,
+  };
+}
+
+export function buildPasteOperations(
+  clipboard: DiagramClipboard,
+  workspaceId: string,
+  viewId: string,
+): ArchitectureOperationInput[] {
+  const offset = 40 * (clipboard.pasteCount + 1);
+  const elementRefs = new Map(
+    clipboard.elements.map((element, index) => [element.id, `copy-element-${index}`] as const),
+  );
+  const relationshipRefs = new Map(
+    clipboard.relationships.map(
+      (relationship, index) => [relationship.id, `copy-relationship-${index}`] as const,
+    ),
+  );
+  const referenceTo = (elementId: string): string => `@${elementRefs.get(elementId)}`;
+  const sameWorkspace = clipboard.workspaceId === workspaceId;
+
+  const operations: ArchitectureOperationInput[] = clipboard.elements.map((element) => ({
+    op: "createElement" as const,
+    ref: elementRefs.get(element.id),
+    data: {
+      parentId: element.parentId
+        ? elementRefs.has(element.parentId)
+          ? referenceTo(element.parentId)
+          : sameWorkspace
+            ? element.parentId
+            : null
+        : null,
+      kind: element.kind,
+      role: element.role,
+      name: `${element.name} (copy)`,
+      description: element.description,
+      technology: element.technology,
+      external: element.external,
+      tags: element.tags,
+      properties: element.properties,
+    },
+  }));
+
+  operations.push({
+    op: "setViewElements",
+    viewId,
+    elementIds: clipboard.elements.map((element) => referenceTo(element.id)),
+    mode: "add",
+  });
+  operations.push({
+    op: "setLayout",
+    viewId,
+    entries: clipboard.elements.map((element) => {
+      const placement = clipboard.placements.find((item) => item.elementId === element.id);
+      return {
+        elementId: referenceTo(element.id),
+        x: (placement?.x ?? 0) + offset,
+        y: (placement?.y ?? 0) + offset,
+        width: placement?.width,
+        height: placement?.height,
+        hidden: false,
+        locked: placement?.locked ?? false,
+        zIndex: placement?.zIndex ?? 0,
+      };
+    }),
+  });
+
+  for (const relationship of clipboard.relationships) {
+    operations.push({
+      op: "createRelationship",
+      ref: relationshipRefs.get(relationship.id),
+      data: {
+        sourceElementId: referenceTo(relationship.sourceElementId),
+        targetElementId: referenceTo(relationship.targetElementId),
+        description: relationship.description,
+        technology: relationship.technology,
+        interactionStyle: relationship.interactionStyle,
+        tags: relationship.tags,
+        properties: relationship.properties,
+      },
+    });
+  }
+
+  if (sameWorkspace && clipboard.viewId === viewId && clipboard.boundaryMemberships.length > 0) {
+    for (const membership of clipboard.boundaryMemberships) {
+      operations.push({
+        op: "setBoundaryMembers",
+        boundaryId: membership.boundaryId,
+        elementIds: membership.elementIds.map(referenceTo),
+        mode: "add",
+      });
+    }
+  }
+
+  const relationshipPatches = clipboard.relationshipPlacements.flatMap((placement) => {
+    const ref = relationshipRefs.get(placement.relationshipId);
+    return ref
+      ? [
+          {
+            relationshipId: `@${ref}`,
+            hidden: placement.hidden,
+            labelPosition: placement.labelPosition,
+            controlPoints: placement.controlPoints.map((point) => ({
+              x: point.x + offset,
+              y: point.y + offset,
+            })),
+          },
+        ]
+      : [];
+  });
+  if (relationshipPatches.length > 0) {
+    operations.push({
+      op: "setViewRelationships",
+      viewId,
+      relationships: relationshipPatches,
+    });
+  }
+
+  return operations;
+}

--- a/apps/web/src/features/canvas/clipboard.ts
+++ b/apps/web/src/features/canvas/clipboard.ts
@@ -6,21 +6,28 @@ import type {
 } from "@structsmith/contracts";
 import type { DiagramClipboard } from "@/store/editor";
 
+export type DiagramCopyMode = "with-connections" | "elements-only";
+
 export function createDiagramClipboard(
   workspaceId: string,
   view: ViewDetail,
   elements: readonly ArchitectureElement[],
   relationships: readonly ArchitectureRelationship[],
   selectedElementIds: readonly string[],
+  mode: DiagramCopyMode = "with-connections",
 ): DiagramClipboard | null {
   const selected = new Set(selectedElementIds);
   const copiedElements = elements.filter((element) => selected.has(element.id));
   if (copiedElements.length === 0) return null;
 
-  const copiedRelationships = relationships.filter(
-    (relationship) =>
-      selected.has(relationship.sourceElementId) && selected.has(relationship.targetElementId),
-  );
+  const copiedRelationships =
+    mode === "with-connections"
+      ? relationships.filter(
+          (relationship) =>
+            selected.has(relationship.sourceElementId) ||
+            selected.has(relationship.targetElementId),
+        )
+      : [];
   const copiedRelationshipIds = new Set(copiedRelationships.map((relationship) => relationship.id));
 
   return {
@@ -49,13 +56,21 @@ export function buildPasteOperations(
   const elementRefs = new Map(
     clipboard.elements.map((element, index) => [element.id, `copy-element-${index}`] as const),
   );
+  const sameWorkspace = clipboard.workspaceId === workspaceId;
+  const relationshipsToPaste = clipboard.relationships.filter(
+    (relationship) =>
+      sameWorkspace ||
+      (elementRefs.has(relationship.sourceElementId) &&
+        elementRefs.has(relationship.targetElementId)),
+  );
   const relationshipRefs = new Map(
-    clipboard.relationships.map(
+    relationshipsToPaste.map(
       (relationship, index) => [relationship.id, `copy-relationship-${index}`] as const,
     ),
   );
   const referenceTo = (elementId: string): string => `@${elementRefs.get(elementId)}`;
-  const sameWorkspace = clipboard.workspaceId === workspaceId;
+  const endpointFor = (elementId: string): string =>
+    elementRefs.has(elementId) ? referenceTo(elementId) : elementId;
 
   const operations: ArchitectureOperationInput[] = clipboard.elements.map((element) => ({
     op: "createElement" as const,
@@ -103,13 +118,13 @@ export function buildPasteOperations(
     }),
   });
 
-  for (const relationship of clipboard.relationships) {
+  for (const relationship of relationshipsToPaste) {
     operations.push({
       op: "createRelationship",
       ref: relationshipRefs.get(relationship.id),
       data: {
-        sourceElementId: referenceTo(relationship.sourceElementId),
-        targetElementId: referenceTo(relationship.targetElementId),
+        sourceElementId: endpointFor(relationship.sourceElementId),
+        targetElementId: endpointFor(relationship.targetElementId),
         description: relationship.description,
         technology: relationship.technology,
         interactionStyle: relationship.interactionStyle,

--- a/apps/web/src/features/canvas/graph.ts
+++ b/apps/web/src/features/canvas/graph.ts
@@ -230,7 +230,9 @@ export function computeBoundaries(
         elementId: parent.id,
       },
       draggable: false,
-      selectable: true,
+      // Derived containers are clickable through Canvas.onNodeClick, but must
+      // stay out of React Flow's rectangle/multi-selection of real elements.
+      selectable: false,
       connectable: false,
       deletable: false,
       zIndex: 0,
@@ -318,7 +320,9 @@ export function computeSemanticBoundaries(
           boundaryId: boundary.id,
         },
         draggable: false,
-        selectable: true,
+        // Boundary boxes are view-owned containers, not blocks in a group
+        // selection. Canvas.onNodeClick still opens their inspector.
+        selectable: false,
         connectable: false,
         deletable: false,
         zIndex: depth,

--- a/apps/web/src/features/command/KeyboardShortcutsDialog.tsx
+++ b/apps/web/src/features/command/KeyboardShortcutsDialog.tsx
@@ -20,7 +20,7 @@ export function KeyboardShortcutsDialog() {
     [t("shortcuts.showShortcuts"), `${primary} /`],
     [t("shortcuts.selectAll"), `${primary} A`],
     [t("shortcuts.addToSelection"), `${primary} + ${t("shortcuts.click")}`],
-    [t("shortcuts.marqueeSelection"), t("shortcuts.dragCanvas")],
+    [t("shortcuts.marqueeSelection"), `${primary} + ${t("shortcuts.dragCanvas")}`],
     [t("shortcuts.copy"), `${primary} C`],
     [t("shortcuts.paste"), `${primary} V`],
     [t("shortcuts.delete"), "Delete / Backspace"],
@@ -28,7 +28,7 @@ export function KeyboardShortcutsDialog() {
     [t("shortcuts.redo"), `${primary} Shift Z`],
     [t("shortcuts.fitView"), "F"],
     [t("shortcuts.clearSelection"), "Escape"],
-    [t("shortcuts.pan"), `${t("shortcuts.space")} + ${t("shortcuts.drag")}`],
+    [t("shortcuts.pan"), t("shortcuts.dragCanvas")],
   ] as const;
 
   return (

--- a/apps/web/src/features/command/KeyboardShortcutsDialog.tsx
+++ b/apps/web/src/features/command/KeyboardShortcutsDialog.tsx
@@ -21,7 +21,7 @@ export function KeyboardShortcutsDialog() {
     [t("shortcuts.selectAll"), `${primary} A`],
     [t("shortcuts.addToSelection"), `${primary} + ${t("shortcuts.click")}`],
     [t("shortcuts.marqueeSelection"), `${primary} + ${t("shortcuts.dragCanvas")}`],
-    [t("shortcuts.copy"), `${primary} C`],
+    [t("shortcuts.copyWithConnections"), `${primary} C`],
     [t("shortcuts.paste"), `${primary} V`],
     [t("shortcuts.delete"), "Delete / Backspace"],
     [t("shortcuts.undo"), `${primary} Z`],

--- a/apps/web/src/features/command/KeyboardShortcutsDialog.tsx
+++ b/apps/web/src/features/command/KeyboardShortcutsDialog.tsx
@@ -1,0 +1,55 @@
+import { useTranslation } from "react-i18next";
+import {
+  Command,
+  CommandEmpty,
+  CommandInput,
+  CommandItem,
+  CommandList,
+} from "@/components/ui/command";
+import { Dialog, DialogContent, DialogTitle } from "@/components/ui/dialog";
+import { primaryModifierLabel } from "@/lib/platform";
+import { useEditorStore } from "@/store/editor";
+
+export function KeyboardShortcutsDialog() {
+  const { t } = useTranslation();
+  const open = useEditorStore((state) => state.shortcutsOpen);
+  const setOpen = useEditorStore((state) => state.setShortcutsOpen);
+  const primary = primaryModifierLabel();
+  const shortcuts = [
+    [t("shortcuts.commandPalette"), `${primary} K`],
+    [t("shortcuts.showShortcuts"), `${primary} /`],
+    [t("shortcuts.selectAll"), `${primary} A`],
+    [t("shortcuts.addToSelection"), `${primary} + ${t("shortcuts.click")}`],
+    [t("shortcuts.marqueeSelection"), t("shortcuts.dragCanvas")],
+    [t("shortcuts.copy"), `${primary} C`],
+    [t("shortcuts.paste"), `${primary} V`],
+    [t("shortcuts.delete"), "Delete / Backspace"],
+    [t("shortcuts.undo"), `${primary} Z`],
+    [t("shortcuts.redo"), `${primary} Shift Z`],
+    [t("shortcuts.fitView"), "F"],
+    [t("shortcuts.clearSelection"), "Escape"],
+    [t("shortcuts.pan"), `${t("shortcuts.space")} + ${t("shortcuts.drag")}`],
+  ] as const;
+
+  return (
+    <Dialog open={open} onOpenChange={setOpen}>
+      <DialogContent className="max-w-md p-0" hideClose>
+        <DialogTitle className="sr-only">{t("shortcuts.title")}</DialogTitle>
+        <Command>
+          <CommandInput placeholder={t("shortcuts.search")} />
+          <CommandList className="max-h-[420px] p-1">
+            <CommandEmpty>{t("shortcuts.empty")}</CommandEmpty>
+            {shortcuts.map(([label, keys]) => (
+              <CommandItem key={label} value={`${label} ${keys}`} className="cursor-default">
+                <span className="flex-1">{label}</span>
+                <kbd className="rounded border border-border bg-muted px-1.5 py-0.5 font-mono text-[10px] text-muted-foreground">
+                  {keys}
+                </kbd>
+              </CommandItem>
+            ))}
+          </CommandList>
+        </Command>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/apps/web/src/features/inspector/Inspector.tsx
+++ b/apps/web/src/features/inspector/Inspector.tsx
@@ -195,7 +195,13 @@ export function Inspector({
             />
           )}
 
-          {!element && !relationship && !boundary && view && (
+          {selection.type === "elements" && (
+            <p className="text-xs text-muted-foreground">
+              {t("inspector.multipleSelected", { count: selection.ids.length })}
+            </p>
+          )}
+
+          {!element && !relationship && !boundary && selection.type !== "elements" && view && (
             <ViewInspector
               key={view.id}
               view={view}

--- a/apps/web/src/features/topbar/TopBar.tsx
+++ b/apps/web/src/features/topbar/TopBar.tsx
@@ -2,6 +2,7 @@ import type { ArchitectureView, LayoutAlgorithm, Workspace } from "@structsmith/
 import {
   Check,
   ChevronDown,
+  Keyboard,
   Languages,
   LayoutGrid,
   Maximize,
@@ -29,6 +30,7 @@ import {
 import { Separator } from "@/components/ui/separator";
 import { Tooltip } from "@/components/ui/tooltip";
 import { supportedLanguages } from "@/i18n";
+import { primaryModifierLabel } from "@/lib/platform";
 import { type Theme, useTheme } from "@/lib/theme";
 import { useEditorStore } from "@/store/editor";
 import { useCopyAgentReference } from "../reference/useCopyAgentReference";
@@ -58,10 +60,12 @@ export function TopBar(props: TopBarProps) {
   const { theme, setTheme } = useTheme();
   const copyReference = useCopyAgentReference();
   const setCommandOpen = useEditorStore((state) => state.setCommandOpen);
+  const setShortcutsOpen = useEditorStore((state) => state.setShortcutsOpen);
   const openElementPalette = useEditorStore((state) => state.openElementPalette);
   const setExplorerTab = useEditorStore((state) => state.setExplorerTab);
 
   const ThemeIcon = theme === "dark" ? Moon : theme === "light" ? Sun : Monitor;
+  const primary = primaryModifierLabel();
 
   return (
     <header className="flex h-10 shrink-0 items-center gap-1 border-b border-border bg-card px-2">
@@ -200,13 +204,13 @@ export function TopBar(props: TopBarProps) {
         </Button>
       </Tooltip>
 
-      <Tooltip label={`${t("topbar.undo")} (⌘Z)`}>
+      <Tooltip label={`${t("topbar.undo")} (${primary}Z)`}>
         <Button variant="ghost" size="iconSm" onClick={props.onUndo} disabled={!props.canUndo}>
           <Undo2 className="h-3.5 w-3.5" />
         </Button>
       </Tooltip>
 
-      <Tooltip label={`${t("topbar.redo")} (⌘⇧Z)`}>
+      <Tooltip label={`${t("topbar.redo")} (${primary}Shift Z)`}>
         <Button variant="ghost" size="iconSm" onClick={props.onRedo} disabled={!props.canRedo}>
           <Redo2 className="h-3.5 w-3.5" />
         </Button>
@@ -214,9 +218,25 @@ export function TopBar(props: TopBarProps) {
 
       <span className="flex-1" />
 
-      <Tooltip label={t("topbar.search")}>
-        <Button variant="ghost" size="iconSm" onClick={() => setCommandOpen(true)}>
+      <Tooltip label={`${t("topbar.search")} (${primary}K)`}>
+        <Button
+          variant="ghost"
+          size="iconSm"
+          aria-label={t("topbar.search")}
+          onClick={() => setCommandOpen(true)}
+        >
           <Search className="h-3.5 w-3.5" />
+        </Button>
+      </Tooltip>
+
+      <Tooltip label={`${t("shortcuts.title")} (${primary}/)`}>
+        <Button
+          variant="ghost"
+          size="iconSm"
+          aria-label={t("shortcuts.title")}
+          onClick={() => setShortcutsOpen(true)}
+        >
+          <Keyboard className="h-3.5 w-3.5" />
         </Button>
       </Tooltip>
 

--- a/apps/web/src/i18n/locales/en.json
+++ b/apps/web/src/i18n/locales/en.json
@@ -324,9 +324,7 @@
     "clearSelection": "Clear selection",
     "pan": "Pan canvas",
     "click": "click",
-    "dragCanvas": "drag canvas",
-    "space": "Space",
-    "drag": "drag"
+    "dragCanvas": "drag canvas"
   },
   "status": {
     "revision": "rev {{revision}}",

--- a/apps/web/src/i18n/locales/en.json
+++ b/apps/web/src/i18n/locales/en.json
@@ -186,6 +186,8 @@
   },
   "contextMenu": {
     "edit": "Edit",
+    "copyWithConnections": "Copy with connections",
+    "copyElementsOnly": "Copy elements only",
     "duplicate": "Duplicate",
     "connect": "Connect from here",
     "hideFromView": "Hide from this view",
@@ -315,7 +317,7 @@
     "selectAll": "Select all elements",
     "addToSelection": "Add to selection",
     "marqueeSelection": "Rectangle selection",
-    "copy": "Copy selected elements",
+    "copyWithConnections": "Copy selected elements with connections",
     "paste": "Paste elements",
     "delete": "Remove selected items",
     "undo": "Undo",

--- a/apps/web/src/i18n/locales/en.json
+++ b/apps/web/src/i18n/locales/en.json
@@ -103,7 +103,7 @@
     "redo": "Redo",
     "export": "Export",
     "more": "More",
-    "search": "Search (⌘K)",
+    "search": "Search",
     "newView": "New view",
     "backHome": "All workspaces"
   },
@@ -138,6 +138,7 @@
   "inspector": {
     "title": "Inspector",
     "nothingSelected": "Select an element or a relationship.",
+    "multipleSelected": "{{count}} elements selected. Move, copy or remove them as a group.",
     "hint": "Changes are saved automatically.",
     "element": "Element",
     "relationship": "Relationship",
@@ -178,7 +179,10 @@
     "legend": "Ownership",
     "empty": "This view has no elements yet",
     "emptyHint": "Add elements from the palette, or drag them in from the model tree.",
-    "hiddenElements": "{{count}} hidden"
+    "hiddenElements": "{{count}} hidden",
+    "copiedElements": "Copied {{count}} element(s)",
+    "pastedElements": "Pasted {{count}} element(s)",
+    "deletedSelection": "Removed selected items"
   },
   "contextMenu": {
     "edit": "Edit",
@@ -301,6 +305,28 @@
     "records": "Records",
     "relationships": "Relationships",
     "actions": "Actions"
+  },
+  "shortcuts": {
+    "title": "Keyboard shortcuts",
+    "search": "Search shortcuts…",
+    "empty": "No matching shortcuts.",
+    "commandPalette": "Open search",
+    "showShortcuts": "Show keyboard shortcuts",
+    "selectAll": "Select all elements",
+    "addToSelection": "Add to selection",
+    "marqueeSelection": "Rectangle selection",
+    "copy": "Copy selected elements",
+    "paste": "Paste elements",
+    "delete": "Remove selected items",
+    "undo": "Undo",
+    "redo": "Redo",
+    "fitView": "Fit view",
+    "clearSelection": "Clear selection",
+    "pan": "Pan canvas",
+    "click": "click",
+    "dragCanvas": "drag canvas",
+    "space": "Space",
+    "drag": "drag"
   },
   "status": {
     "revision": "rev {{revision}}",

--- a/apps/web/src/i18n/locales/pl.json
+++ b/apps/web/src/i18n/locales/pl.json
@@ -107,7 +107,7 @@
     "redo": "Ponów",
     "export": "Eksport",
     "more": "Więcej",
-    "search": "Szukaj (⌘K)",
+    "search": "Szukaj",
     "newView": "Nowy widok",
     "backHome": "Wszystkie przestrzenie"
   },
@@ -142,6 +142,7 @@
   "inspector": {
     "title": "Inspektor",
     "nothingSelected": "Wybierz element lub relację.",
+    "multipleSelected": "Wybrano {{count}} elementów. Możesz je razem przesuwać, kopiować lub usuwać.",
     "hint": "Zmiany zapisują się automatycznie.",
     "element": "Element",
     "relationship": "Relacja",
@@ -182,7 +183,10 @@
     "legend": "Własność",
     "empty": "Ten widok nie zawiera jeszcze elementów",
     "emptyHint": "Dodaj elementy z palety lub przeciągnij je z drzewa modelu.",
-    "hiddenElements": "ukryte: {{count}}"
+    "hiddenElements": "ukryte: {{count}}",
+    "copiedElements": "Skopiowano elementy: {{count}}",
+    "pastedElements": "Wklejono elementy: {{count}}",
+    "deletedSelection": "Usunięto wybrane elementy"
   },
   "contextMenu": {
     "edit": "Edytuj",
@@ -305,6 +309,28 @@
     "records": "Wpisy",
     "relationships": "Relacje",
     "actions": "Akcje"
+  },
+  "shortcuts": {
+    "title": "Skróty klawiszowe",
+    "search": "Szukaj skrótów…",
+    "empty": "Brak pasujących skrótów.",
+    "commandPalette": "Otwórz wyszukiwanie",
+    "showShortcuts": "Pokaż skróty klawiszowe",
+    "selectAll": "Zaznacz wszystkie elementy",
+    "addToSelection": "Dodaj do zaznaczenia",
+    "marqueeSelection": "Zaznaczenie prostokątem",
+    "copy": "Kopiuj zaznaczone elementy",
+    "paste": "Wklej elementy",
+    "delete": "Usuń zaznaczone elementy",
+    "undo": "Cofnij",
+    "redo": "Ponów",
+    "fitView": "Dopasuj widok",
+    "clearSelection": "Wyczyść zaznaczenie",
+    "pan": "Przesuń kanwę",
+    "click": "kliknięcie",
+    "dragCanvas": "przeciągnięcie po kanwie",
+    "space": "Spacja",
+    "drag": "przeciągnięcie"
   },
   "status": {
     "revision": "rew. {{revision}}",

--- a/apps/web/src/i18n/locales/pl.json
+++ b/apps/web/src/i18n/locales/pl.json
@@ -328,9 +328,7 @@
     "clearSelection": "Wyczyść zaznaczenie",
     "pan": "Przesuń kanwę",
     "click": "kliknięcie",
-    "dragCanvas": "przeciągnięcie po kanwie",
-    "space": "Spacja",
-    "drag": "przeciągnięcie"
+    "dragCanvas": "przeciągnięcie po kanwie"
   },
   "status": {
     "revision": "rew. {{revision}}",

--- a/apps/web/src/i18n/locales/pl.json
+++ b/apps/web/src/i18n/locales/pl.json
@@ -190,6 +190,8 @@
   },
   "contextMenu": {
     "edit": "Edytuj",
+    "copyWithConnections": "Kopiuj z połączeniami",
+    "copyElementsOnly": "Kopiuj same elementy",
     "duplicate": "Duplikuj",
     "connect": "Połącz stąd",
     "hideFromView": "Ukryj w tym widoku",
@@ -319,7 +321,7 @@
     "selectAll": "Zaznacz wszystkie elementy",
     "addToSelection": "Dodaj do zaznaczenia",
     "marqueeSelection": "Zaznaczenie prostokątem",
-    "copy": "Kopiuj zaznaczone elementy",
+    "copyWithConnections": "Kopiuj zaznaczone elementy z połączeniami",
     "paste": "Wklej elementy",
     "delete": "Usuń zaznaczone elementy",
     "undo": "Cofnij",

--- a/apps/web/src/lib/platform.ts
+++ b/apps/web/src/lib/platform.ts
@@ -1,0 +1,17 @@
+/** React Flow uses the same platform split for its built-in multi-selection key. */
+export function isApplePlatform(): boolean {
+  if (typeof navigator === "undefined") return false;
+  return /Mac|iPhone|iPad|iPod/i.test(navigator.userAgent);
+}
+
+export function primaryModifierLabel(): string {
+  return isApplePlatform() ? "⌘" : "Ctrl";
+}
+
+export function primaryModifierKeyCode(): "Meta" | "Control" {
+  return isApplePlatform() ? "Meta" : "Control";
+}
+
+export function hasPrimaryModifier(event: Pick<KeyboardEvent, "metaKey" | "ctrlKey">): boolean {
+  return isApplePlatform() ? event.metaKey : event.ctrlKey;
+}

--- a/apps/web/src/routes/StudioPage.tsx
+++ b/apps/web/src/routes/StudioPage.tsx
@@ -6,6 +6,7 @@ import { toast } from "sonner";
 import { Canvas } from "@/features/canvas/Canvas";
 import { CommandPalette } from "@/features/command/CommandPalette";
 import { ElementPalette } from "@/features/command/ElementPalette";
+import { KeyboardShortcutsDialog } from "@/features/command/KeyboardShortcutsDialog";
 import { Explorer } from "@/features/explorer/Explorer";
 import { Inspector } from "@/features/inspector/Inspector";
 import { BottomPanel } from "@/features/panels/BottomPanel";
@@ -25,6 +26,7 @@ import {
 import { useHistory } from "@/hooks/useHistory";
 import { useWorkspaceEvents } from "@/hooks/useWorkspaceEvents";
 import { parseReferenceSearchValue } from "@/lib/agentReference";
+import { hasPrimaryModifier } from "@/lib/platform";
 import { useEditorStore } from "@/store/editor";
 import { useHistoryStore } from "@/store/history";
 
@@ -76,6 +78,7 @@ function StudioContent({
   const requestFocus = useEditorStore((state) => state.requestFocus);
   const setExplorerTab = useEditorStore((state) => state.setExplorerTab);
   const setCommandOpen = useEditorStore((state) => state.setCommandOpen);
+  const setShortcutsOpen = useEditorStore((state) => state.setShortcutsOpen);
   const handledReference = useRef<string | null>(null);
 
   useWorkspaceEvents(workspaceId);
@@ -160,19 +163,24 @@ function StudioContent({
         target?.tagName === "INPUT" ||
         target?.tagName === "TEXTAREA" ||
         target?.isContentEditable === true;
-      const meta = event.metaKey || event.ctrlKey;
+      const primary = hasPrimaryModifier(event);
 
-      if (meta && event.key.toLowerCase() === "k") {
+      if (primary && event.key.toLowerCase() === "k") {
         event.preventDefault();
         setCommandOpen(true);
         return;
       }
-      if (meta && event.key.toLowerCase() === "z") {
+      if (primary && event.key === "/") {
+        event.preventDefault();
+        setShortcutsOpen(true);
+        return;
+      }
+      if (primary && event.key.toLowerCase() === "z") {
         event.preventDefault();
         void (event.shiftKey ? history.redo() : history.undo());
         return;
       }
-      if (meta && event.key.toLowerCase() === "s") {
+      if (primary && event.key.toLowerCase() === "s") {
         event.preventDefault();
         toast.success(t("status.saved"));
         return;
@@ -282,6 +290,7 @@ function StudioContent({
       />
 
       <ElementPalette workspaceId={workspaceId} view={view.data ?? null} />
+      <KeyboardShortcutsDialog />
       <CommandPalette
         elements={elements}
         relationships={relationships}

--- a/apps/web/src/store/editor.ts
+++ b/apps/web/src/store/editor.ts
@@ -1,15 +1,46 @@
+import type {
+  ArchitectureElement,
+  ArchitectureRelationship,
+  ViewElement,
+  ViewRelationship,
+} from "@structsmith/contracts";
 import { create } from "zustand";
 
 export type Selection =
   | { type: "none" }
   | { type: "element"; id: string }
+  | { type: "elements"; ids: string[] }
   | { type: "boundary"; id: string }
   | { type: "relationship"; id: string }
   | { type: "view"; id: string }
   | { type: "record"; id: string };
 
+export interface DiagramClipboard {
+  workspaceId: string;
+  viewId: string;
+  elements: ArchitectureElement[];
+  relationships: ArchitectureRelationship[];
+  placements: ViewElement[];
+  relationshipPlacements: ViewRelationship[];
+  boundaryMemberships: { boundaryId: string; elementIds: string[] }[];
+  pasteCount: number;
+}
+
 export type ExplorerTab = "model" | "views" | "presales";
 export type BottomPanel = "issues" | "activity" | "snapshots" | null;
+
+function sameSelection(current: Selection, next: Selection): boolean {
+  if (current.type !== next.type) return false;
+  if (current.type === "none" && next.type === "none") return true;
+  if (current.type === "elements" && next.type === "elements") {
+    return (
+      current.ids.length === next.ids.length &&
+      current.ids.every((id, index) => id === next.ids[index])
+    );
+  }
+  if ("id" in current && "id" in next) return current.id === next.id;
+  return false;
+}
 
 interface EditorState {
   /** Short-lived editor state only — server state lives in TanStack Query. */
@@ -17,23 +48,27 @@ interface EditorState {
   explorerTab: ExplorerTab;
   bottomPanel: BottomPanel;
   commandOpen: boolean;
+  shortcutsOpen: boolean;
   paletteOpen: boolean;
   paletteBoundaryId: string | null;
   connectFrom: string | null;
   focusRequest: { elementId: string; nonce: number } | null;
   pendingSave: number;
+  clipboard: DiagramClipboard | null;
 
   select: (selection: Selection) => void;
   clearSelection: () => void;
   setExplorerTab: (tab: ExplorerTab) => void;
   setBottomPanel: (panel: BottomPanel) => void;
   setCommandOpen: (open: boolean) => void;
+  setShortcutsOpen: (open: boolean) => void;
   setPaletteOpen: (open: boolean) => void;
   openElementPalette: (boundaryId?: string | null) => void;
   setConnectFrom: (elementId: string | null) => void;
   requestFocus: (elementId: string) => void;
   beginSave: () => void;
   endSave: () => void;
+  setClipboard: (clipboard: DiagramClipboard | null) => void;
 }
 
 export const useEditorStore = create<EditorState>((set) => ({
@@ -41,18 +76,27 @@ export const useEditorStore = create<EditorState>((set) => ({
   explorerTab: "model",
   bottomPanel: null,
   commandOpen: false,
+  shortcutsOpen: false,
   paletteOpen: false,
   paletteBoundaryId: null,
   connectFrom: null,
   focusRequest: null,
   pendingSave: 0,
+  clipboard: null,
 
-  select: (selection) => set({ selection }),
-  clearSelection: () => set({ selection: { type: "none" }, connectFrom: null }),
+  select: (selection) =>
+    set((state) => (sameSelection(state.selection, selection) ? state : { ...state, selection })),
+  clearSelection: () =>
+    set((state) =>
+      state.selection.type === "none" && state.connectFrom === null
+        ? state
+        : { ...state, selection: { type: "none" }, connectFrom: null },
+    ),
   setExplorerTab: (explorerTab) => set({ explorerTab }),
   setBottomPanel: (bottomPanel) =>
     set((state) => ({ bottomPanel: state.bottomPanel === bottomPanel ? null : bottomPanel })),
   setCommandOpen: (commandOpen) => set({ commandOpen }),
+  setShortcutsOpen: (shortcutsOpen) => set({ shortcutsOpen }),
   setPaletteOpen: (paletteOpen) =>
     set({ paletteOpen, ...(paletteOpen ? {} : { paletteBoundaryId: null }) }),
   openElementPalette: (paletteBoundaryId = null) => set({ paletteOpen: true, paletteBoundaryId }),
@@ -60,4 +104,5 @@ export const useEditorStore = create<EditorState>((set) => ({
   requestFocus: (elementId) => set({ focusRequest: { elementId, nonce: Date.now() } }),
   beginSave: () => set((state) => ({ pendingSave: state.pendingSave + 1 })),
   endSave: () => set((state) => ({ pendingSave: Math.max(0, state.pendingSave - 1) })),
+  setClipboard: (clipboard) => set({ clipboard }),
 }));

--- a/package.json
+++ b/package.json
@@ -19,22 +19,6 @@
     "software-architecture",
     "local-first"
   ],
-  "homepage": "https://dziksu.github.io/StructSmith/",
-  "repository": {
-    "type": "git",
-    "url": "git+https://github.com/dziksu/structsmith.git"
-  },
-  "bugs": {
-    "url": "https://github.com/dziksu/structsmith/issues"
-  },
-  "engines": {
-    "bun": ">=1.2.0"
-  },
-  "type": "module",
-  "workspaces": [
-    "apps/*",
-    "packages/*"
-  ],
   "scripts": {
     "dev": "bun run scripts/dev.ts",
     "dev:server": "bun --watch apps/server/src/index.ts",
@@ -57,6 +41,22 @@
     "mcp:stdio": "bun apps/server/src/mcp-stdio.ts",
     "release": "node scripts/release.ts"
   },
+  "homepage": "https://dziksu.github.io/StructSmith/",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/dziksu/structsmith.git"
+  },
+  "bugs": {
+    "url": "https://github.com/dziksu/structsmith/issues"
+  },
+  "engines": {
+    "bun": ">=1.2.0"
+  },
+  "type": "module",
+  "workspaces": [
+    "apps/*",
+    "packages/*"
+  ],
   "overrides": {
     "zod": "^4.5.4"
   },


### PR DESCRIPTION
## What and why

Adds native React Flow multi-selection and group operations for larger diagrams:

- drag with the left mouse button to pan
- hold Cmd on macOS or Ctrl on Windows/Linux and drag to select multiple blocks
- use Cmd/Ctrl + A/C/V and Delete/Backspace for common actions
- move and delete selected blocks as a group
- copy with relationships by default, with context-menu options for both “Copy with connections” and “Copy elements only”
- preserve relationships between copied blocks
- keep selected boundaries behind their contents so boundaries do not block clicking nested elements
- add a searchable keyboard-shortcuts dialog with platform-aware labels

The implementation uses React Flow behavior where available. Semantic data remains in the domain model, while positions and layout stay on views.

## How to verify

1. Open a diagram containing boundaries, nested elements, and relationships.
2. Confirm left-drag pans the canvas.
3. Hold Cmd (macOS) or Ctrl (Windows/Linux), drag a selection rectangle, and move or delete the selected group.
4. Verify Cmd/Ctrl + A/C/V and Delete/Backspace.
5. Right-click a multi-selection and test both copy modes; confirm the default copy preserves connections.
6. Select a boundary, then click a nested element and confirm the boundary does not block interaction.
7. Open the shortcuts dialog and search for an action.

Validated locally:

- `bun run test` — 68 tests passed
- `bun run typecheck`
- `bun run check`
- `bun run build:web`
- manual canvas interaction checks

## Checklist

- [x] `bun run check`, `bun run typecheck`, `bun run test` and `bun run build:web` pass
- [x] The semantic model stays the source of truth — no data lives only in React Flow state
- [x] Layout changes touch views, not elements
- [x] REST and MCP still go through the same domain services
- [x] New DTOs are defined in `packages/contracts`
- [x] User-facing copy goes through i18n (`en` and `pl` locales updated)
