### PR TITLE
fix(layout): ignore edges to dagre clusters

### DIFF
--- a/packages/domain/src/layout.ts
+++ b/packages/domain/src/layout.ts
@@ -211,6 +211,7 @@ function computeDagreLayout(
   for (const parentId of detachedParents) {
     graph.setNode(clusterId(parentId), {});
   }
+  const compoundNodeIds = new Set<string>();
   for (const node of nodes) {
     if (node.groupId && groupIds.has(node.groupId)) {
       graph.setParent(node.id, clusterId(node.groupId));
@@ -219,12 +220,22 @@ function computeDagreLayout(
     if (!node.parentId) continue;
     if (present.has(node.parentId)) {
       graph.setParent(node.id, node.parentId);
+      compoundNodeIds.add(node.parentId);
     } else if (detachedParents.has(node.parentId)) {
       graph.setParent(node.id, clusterId(node.parentId));
     }
   }
   for (const edge of edges) {
-    if (!present.has(edge.source) || !present.has(edge.target) || edge.source === edge.target) {
+    if (
+      !present.has(edge.source) ||
+      !present.has(edge.target) ||
+      edge.source === edge.target ||
+      // Dagre uses visible parents as compound clusters and crashes when an
+      // edge endpoint is a cluster. Keep those semantic relationships in the
+      // view, but omit them from the layout graph.
+      compoundNodeIds.has(edge.source) ||
+      compoundNodeIds.has(edge.target)
+    ) {
       continue;
     }
     const label = estimateLabelSize(edge.label);

--- a/tests/dependency-migrations.test.ts
+++ b/tests/dependency-migrations.test.ts
@@ -99,6 +99,36 @@ describe("Dagre layout", () => {
       expect(Number.isFinite(position.x) && Number.isFinite(position.y)).toBe(true);
     }
   });
+
+  test("ignores edges to visible parent clusters", () => {
+    const nodes = [
+      { id: "system" },
+      { id: "api", parentId: "system" },
+      { id: "database", parentId: "system" },
+      { id: "customer" },
+    ];
+    const edges = [
+      { source: "customer", target: "system" },
+      { source: "system", target: "database" },
+      { source: "api", target: "database" },
+    ];
+
+    for (const direction of ["LR", "TB"] as const) {
+      const positions = computeLayout(nodes, edges, direction, "dagre");
+      expect(positions.map((position) => position.id)).toEqual([
+        "system",
+        "api",
+        "database",
+        "customer",
+      ]);
+      expect(positions.every(({ x, y }) => Number.isFinite(x) && Number.isFinite(y))).toBe(true);
+      const byId = new Map(positions.map((position) => [position.id, position] as const));
+      const api = byId.get("api");
+      const database = byId.get("database");
+      if (!api || !database) throw new Error("Missing child layout positions");
+      expect(direction === "LR" ? database.x > api.x : database.y > api.y).toBe(true);
+    }
+  });
 });
 
 describe("Canvas relationship presentation", () => {

--- a/tests/operations.test.ts
+++ b/tests/operations.test.ts
@@ -101,6 +101,55 @@ describe("batch operations", () => {
     close();
   });
 
+  test("auto-layout handles a visible parent with children and a relationship to the parent", () => {
+    const { services, close } = createTestContext();
+    try {
+      const workspace = createWorkspace(services);
+      const system = services.elements.create(workspace.id, {
+        kind: "softwareSystem",
+        name: "Payments Platform",
+      }).result;
+      const api = services.elements.create(workspace.id, {
+        kind: "container",
+        parentId: system.id,
+        name: "Payments API",
+      }).result;
+      const database = services.elements.create(workspace.id, {
+        kind: "container",
+        parentId: system.id,
+        name: "Payments Database",
+      }).result;
+      const customer = services.elements.create(workspace.id, {
+        kind: "person",
+        name: "Customer",
+      }).result;
+      services.relationships.create(workspace.id, {
+        sourceElementId: customer.id,
+        targetElementId: system.id,
+        description: "Uses",
+      });
+      services.relationships.create(workspace.id, {
+        sourceElementId: api.id,
+        targetElementId: database.id,
+        description: "Reads and writes",
+      });
+      const view = services.views.create(workspace.id, {
+        kind: "container",
+        name: "All elements",
+        elementIds: [system.id, api.id, database.id, customer.id],
+      }).result;
+
+      const result = services.views.autoLayout(workspace.id, view.id, "LR", "dagre").result;
+
+      expect(result.elements).toHaveLength(4);
+      expect(result.elements.every(({ x, y }) => Number.isFinite(x) && Number.isFinite(y))).toBe(
+        true,
+      );
+    } finally {
+      close();
+    }
+  });
+
   test("a failing operation rolls the whole batch back", () => {
     const { services, close } = createTestContext();
     const workspace = createWorkspace(services);


### PR DESCRIPTION
## What and why

Dagre crashes when a view contains a visible parent together with its children and a relationship targets or originates from that parent. Visible parents are represented as compound clusters, and Dagre does not support cluster nodes as edge endpoints.

This change omits those relationships only from the Dagre layout graph. The semantic relationship remains in the model and view, while ordinary child-to-child relationships continue to influence layout.

Adds regression coverage at both the pure layout helper and domain service levels, including LR and TB directions.

## How to verify

1. Run `bun test`.
2. Run `bun run typecheck`.
3. Run `bun run check`.
4. Run `bun run build`.
5. In the UI, create a Container view with Scope → All elements where the parent and children are visible and a relationship points to the parent. Run hierarchical auto-layout and verify it completes without an error toast.

## Checklist

- [x] `bun run check`, `bun run typecheck`, `bun run test` and `bun run build` pass
- [x] The semantic model stays the source of truth — no data lives only in React Flow state
- [x] Layout changes touch views, not elements
- [x] REST and MCP still go through the same domain services
- [x] No new DTOs are required
- [x] No user-facing copy was added