### PR TITLE
fix(editor): improve view creation and layout workflow

### DIFF
--- a/apps/web/src/features/canvas/BoundaryNode.tsx
+++ b/apps/web/src/features/canvas/BoundaryNode.tsx
@@ -49,7 +49,9 @@ function BoundaryNodeComponent({ data, selected }: NodeProps & { data: BoundaryN
         >
           {data.classification
             ? t(`boundaries.classification.${data.classification}`)
-            : t(`boundaries.layer.${data.layer}`)}
+            : data.kind
+              ? t(`kinds.${data.kind}`)
+              : t(`boundaries.layer.${data.layer}`)}
         </span>
       </div>
     </div>

--- a/apps/web/src/features/canvas/Canvas.tsx
+++ b/apps/web/src/features/canvas/Canvas.tsx
@@ -340,17 +340,28 @@ export function Canvas({
       if (sourceElementId === targetElementId) return;
       const source = elementsById.get(sourceElementId)?.name ?? sourceElementId;
       const target = elementsById.get(targetElementId)?.name ?? targetElementId;
-      applyOperations.mutate({
-        label: `Connected ${source} → ${target}`,
-        operations: [
-          {
-            op: "createRelationship",
-            data: { sourceElementId, targetElementId, interactionStyle: "sync" },
+      applyOperations.mutate(
+        {
+          label: `Connected ${source} → ${target}`,
+          operations: [
+            {
+              op: "createRelationship",
+              ref: "relationship",
+              data: { sourceElementId, targetElementId, interactionStyle: "sync" },
+            },
+          ],
+        },
+        {
+          onSuccess: (result) => {
+            const created = result.appliedOperations.find(
+              (operation) => operation.ref === "relationship",
+            );
+            if (created?.id) select({ type: "relationship", id: created.id });
           },
-        ],
-      });
+        },
+      );
     },
-    [applyOperations, elementsById],
+    [applyOperations, elementsById, select],
   );
 
   const onConnect = useCallback(

--- a/apps/web/src/features/canvas/RelationshipEdge.tsx
+++ b/apps/web/src/features/canvas/RelationshipEdge.tsx
@@ -24,6 +24,12 @@ export function relationshipFocus(
     : "dimmed";
 }
 
+export function relationshipLabelBackground(focus: RelationshipFocus): string {
+  return focus === "connected"
+    ? "color-mix(in oklch, var(--primary) 12%, var(--card))"
+    : "var(--card)";
+}
+
 /**
  * Interaction style drives the line style; colour is purely presentation and
  * never stored on the model (spec §12).
@@ -90,13 +96,14 @@ function RelationshipEdgeComponent({
         <EdgeLabelRenderer>
           <div
             className={cn(
-              "pointer-events-none absolute max-w-[170px] rounded border bg-card/95 px-1.5 py-0.5 text-center text-[10px] font-medium leading-[1.3] shadow-sm transition-[border-color,background-color,opacity] duration-150",
+              "pointer-events-none absolute max-w-[170px] rounded border px-1.5 py-0.5 text-center text-[10px] font-medium leading-[1.3] shadow-sm transition-[border-color,background-color,opacity] duration-150",
               focus === "connected"
-                ? "border-primary/70 bg-primary/10 text-foreground"
+                ? "border-primary/70 text-foreground"
                 : "border-border text-foreground",
             )}
             style={{
               transform: `translate(-50%, -50%) translate(${labelX}px, ${labelY}px)`,
+              backgroundColor: relationshipLabelBackground(focus),
               opacity: focus === "dimmed" ? 0.75 : 1,
               // Wrap to at most three lines — the layout reserves exactly this box.
               display: "-webkit-box",

--- a/apps/web/src/features/canvas/graph.ts
+++ b/apps/web/src/features/canvas/graph.ts
@@ -30,7 +30,8 @@ export interface ElementNodeData extends Record<string, unknown> {
 
 export interface BoundaryNodeData extends Record<string, unknown> {
   name: string;
-  layer: string;
+  layer?: ArchitectureBoundary["layer"];
+  kind?: ArchitectureElement["kind"];
   classification: "public" | "restricted" | "private" | null;
   boundaryId?: string;
   elementId?: string;
@@ -225,7 +226,7 @@ export function computeBoundaries(
       height: maxY - minY + BOUNDARY_PADDING * 2 + BOUNDARY_HEADER,
       data: {
         name: parent.name,
-        layer: "deployment",
+        kind: parent.kind,
         classification: parent.external ? "public" : null,
         elementId: parent.id,
       },

--- a/apps/web/src/features/explorer/ModelTree.tsx
+++ b/apps/web/src/features/explorer/ModelTree.tsx
@@ -176,20 +176,31 @@ export function ModelTree({ workspaceId, elements, boundaries, view }: ModelTree
 
   const createBoundary = (): void => {
     if (!view) return;
-    applyOperations.mutate({
-      label: t("boundaries.created"),
-      operations: [
-        {
-          op: "createBoundary",
-          data: {
-            viewId: view.id,
-            name: t("boundaries.newName"),
-            kind: "networkZone",
-            layer: view.settings.boundaryLayer,
+    applyOperations.mutate(
+      {
+        label: t("boundaries.created"),
+        operations: [
+          {
+            op: "createBoundary",
+            ref: "boundary",
+            data: {
+              viewId: view.id,
+              name: t("boundaries.newName"),
+              kind: "networkZone",
+              layer: view.settings.boundaryLayer,
+            },
           },
+        ],
+      },
+      {
+        onSuccess: (result) => {
+          const created = result.appliedOperations.find(
+            (operation) => operation.ref === "boundary",
+          );
+          if (created?.id) select({ type: "boundary", id: created.id });
         },
-      ],
-    });
+      },
+    );
   };
 
   const startElementDrag = (event: React.DragEvent, elementId: string): void => {

--- a/apps/web/src/features/explorer/ViewsPanel.tsx
+++ b/apps/web/src/features/explorer/ViewsPanel.tsx
@@ -25,6 +25,7 @@ import { Tooltip } from "@/components/ui/tooltip";
 import { useApplyOperations } from "@/hooks/useApi";
 import { cn } from "@/lib/utils";
 import { CopyReferenceButton } from "../reference/CopyReferenceButton";
+import { initialViewElementIds } from "./viewSeed";
 
 const VIEW_KINDS: ViewKind[] = [
   "systemContext",
@@ -60,6 +61,7 @@ export function ViewsPanel({
 
   const create = (): void => {
     if (!name.trim()) return;
+    const scopeElementId = scope === "none" ? null : scope;
     applyOperations.mutate(
       {
         label: t("views.create"),
@@ -70,8 +72,8 @@ export function ViewsPanel({
             data: {
               name: name.trim(),
               kind,
-              scopeElementId: scope === "none" ? null : scope,
-              elementIds: seed === "all" ? elements.map((element) => element.id) : [],
+              scopeElementId,
+              elementIds: seed === "all" ? initialViewElementIds(elements, scopeElementId) : [],
             },
           },
           { op: "autoLayoutView", viewId: "@view", direction: "LR" },

--- a/apps/web/src/features/explorer/viewSeed.test.ts
+++ b/apps/web/src/features/explorer/viewSeed.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, test } from "bun:test";
+import { initialViewElementIds } from "./viewSeed";
+
+const elements = [
+  { id: "customer", parentId: null },
+  { id: "payments", parentId: null },
+  { id: "checkout", parentId: "payments" },
+  { id: "ledger", parentId: "payments" },
+  { id: "repository", parentId: "ledger" },
+  { id: "unrelated", parentId: null },
+];
+
+describe("new view element seeding", () => {
+  test("includes every workspace element when the view has no scope", () => {
+    expect(initialViewElementIds(elements, null)).toEqual(elements.map((element) => element.id));
+  });
+
+  test("includes only descendants when the view has a scope", () => {
+    expect(initialViewElementIds(elements, "payments")).toEqual([
+      "checkout",
+      "ledger",
+      "repository",
+    ]);
+  });
+});

--- a/apps/web/src/features/explorer/viewSeed.ts
+++ b/apps/web/src/features/explorer/viewSeed.ts
@@ -1,0 +1,27 @@
+import type { ArchitectureElement } from "@structsmith/contracts";
+
+/** Resolve the initial contents of an "All elements" view without leaking outside its scope. */
+export function initialViewElementIds(
+  elements: readonly Pick<ArchitectureElement, "id" | "parentId">[],
+  scopeElementId: string | null,
+): string[] {
+  if (!scopeElementId) return elements.map((element) => element.id);
+
+  const descendants = new Set<string>();
+  let foundAnother = true;
+  while (foundAnother) {
+    foundAnother = false;
+    for (const element of elements) {
+      if (
+        !descendants.has(element.id) &&
+        (element.parentId === scopeElementId ||
+          (element.parentId !== null && descendants.has(element.parentId)))
+      ) {
+        descendants.add(element.id);
+        foundAnother = true;
+      }
+    }
+  }
+
+  return elements.filter((element) => descendants.has(element.id)).map((element) => element.id);
+}

--- a/apps/web/src/features/inspector/Inspector.tsx
+++ b/apps/web/src/features/inspector/Inspector.tsx
@@ -800,7 +800,9 @@ function RelationshipInspector({
       </div>
 
       <Field label={t("common.description")}>
-        <Input
+        <Textarea
+          autoFocus
+          rows={3}
           value={description}
           onChange={(event) => {
             setDescription(event.target.value);

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -180,10 +180,10 @@
   fill: var(--muted-foreground);
   opacity: 0.55;
 }
-/* React Flow renders edge labels below the node layer by default, which clips
-   them behind nodes. Labels are small chips, so they read better on top. */
+/* Diagram edges use z-index 10 and nodes start at 20. Keep labels above the
+   lines without allowing them to cover cards. */
 .react-flow__edgelabel-renderer {
-  z-index: 3;
+  z-index: 15;
 }
 .react-flow__handle {
   background: var(--muted-foreground);

--- a/packages/domain/src/layout.ts
+++ b/packages/domain/src/layout.ts
@@ -211,31 +211,17 @@ function computeDagreLayout(
   for (const parentId of detachedParents) {
     graph.setNode(clusterId(parentId), {});
   }
-  const compoundNodeIds = new Set<string>();
   for (const node of nodes) {
     if (node.groupId && groupIds.has(node.groupId)) {
       graph.setParent(node.id, clusterId(node.groupId));
       continue;
     }
-    if (!node.parentId) continue;
-    if (present.has(node.parentId)) {
-      graph.setParent(node.id, node.parentId);
-      compoundNodeIds.add(node.parentId);
-    } else if (detachedParents.has(node.parentId)) {
+    if (node.parentId && detachedParents.has(node.parentId)) {
       graph.setParent(node.id, clusterId(node.parentId));
     }
   }
   for (const edge of edges) {
-    if (
-      !present.has(edge.source) ||
-      !present.has(edge.target) ||
-      edge.source === edge.target ||
-      // Dagre uses visible parents as compound clusters and crashes when an
-      // edge endpoint is a cluster. Keep those semantic relationships in the
-      // view, but omit them from the layout graph.
-      compoundNodeIds.has(edge.source) ||
-      compoundNodeIds.has(edge.target)
-    ) {
+    if (!present.has(edge.source) || !present.has(edge.target) || edge.source === edge.target) {
       continue;
     }
     const label = estimateLabelSize(edge.label);

--- a/tests/boundaries.test.ts
+++ b/tests/boundaries.test.ts
@@ -1,9 +1,45 @@
 import { describe, expect, test } from "bun:test";
 import { computeLayout, toMermaid, validateDocument } from "@structsmith/domain";
-import { computeSemanticBoundaries } from "../apps/web/src/features/canvas/graph";
+import {
+  computeBoundaries,
+  computeSemanticBoundaries,
+} from "../apps/web/src/features/canvas/graph";
 import { createTestContext, createWorkspace } from "./helpers";
 
 describe("semantic boundaries", () => {
+  test("labels a derived parent frame with the parent element kind", () => {
+    const { services, close } = createTestContext();
+    try {
+      const workspace = createWorkspace(services);
+      const system = services.elements.create(workspace.id, {
+        kind: "softwareSystem",
+        name: "Payments Platform",
+      }).result;
+      const api = services.elements.create(workspace.id, {
+        kind: "container",
+        parentId: system.id,
+        name: "Payments API",
+      }).result;
+      const elements = services.elements.list(workspace.id);
+
+      const frames = computeBoundaries(
+        [{ id: api.id, x: 100, y: 100, width: 220, height: 96 }],
+        new Map(elements.map((element) => [element.id, element] as const)),
+        true,
+      );
+
+      expect(frames).toHaveLength(1);
+      expect(frames[0]?.data).toMatchObject({
+        name: "Payments Platform",
+        kind: "softwareSystem",
+        elementId: system.id,
+      });
+      expect(frames[0]?.data).not.toHaveProperty("layer");
+    } finally {
+      close();
+    }
+  });
+
   test("keeps boundary trees and memberships independent between views", () => {
     const { services, close } = createTestContext();
     try {

--- a/tests/dependency-migrations.test.ts
+++ b/tests/dependency-migrations.test.ts
@@ -100,7 +100,7 @@ describe("Dagre layout", () => {
     }
   });
 
-  test("ignores edges to visible parent clusters", () => {
+  test("keeps edges to visible parents in the layout graph", () => {
     const nodes = [
       { id: "system" },
       { id: "api", parentId: "system" },
@@ -123,9 +123,13 @@ describe("Dagre layout", () => {
       ]);
       expect(positions.every(({ x, y }) => Number.isFinite(x) && Number.isFinite(y))).toBe(true);
       const byId = new Map(positions.map((position) => [position.id, position] as const));
+      const customer = byId.get("customer");
+      const system = byId.get("system");
       const api = byId.get("api");
       const database = byId.get("database");
-      if (!api || !database) throw new Error("Missing child layout positions");
+      if (!customer || !system || !api || !database) throw new Error("Missing layout positions");
+      expect(direction === "LR" ? system.x > customer.x : system.y > customer.y).toBe(true);
+      expect(direction === "LR" ? database.x > system.x : database.y > system.y).toBe(true);
       expect(direction === "LR" ? database.x > api.x : database.y > api.y).toBe(true);
     }
   });

--- a/tests/operations.test.ts
+++ b/tests/operations.test.ts
@@ -145,6 +145,13 @@ describe("batch operations", () => {
       expect(result.elements.every(({ x, y }) => Number.isFinite(x) && Number.isFinite(y))).toBe(
         true,
       );
+      const byId = new Map(result.elements.map((entry) => [entry.elementId, entry] as const));
+      expect(byId.get(system.id)?.x).toBeGreaterThan(
+        byId.get(customer.id)?.x ?? Number.POSITIVE_INFINITY,
+      );
+      expect(byId.get(database.id)?.x).toBeGreaterThan(
+        byId.get(api.id)?.x ?? Number.POSITIVE_INFINITY,
+      );
     } finally {
       close();
     }

--- a/tests/view-presentation.test.ts
+++ b/tests/view-presentation.test.ts
@@ -1,7 +1,10 @@
 import { expect, test } from "bun:test";
 import { UpdateViewSchema } from "@structsmith/contracts";
 import { buildGraph } from "../apps/web/src/features/canvas/graph";
-import { relationshipFocus } from "../apps/web/src/features/canvas/RelationshipEdge";
+import {
+  relationshipFocus,
+  relationshipLabelBackground,
+} from "../apps/web/src/features/canvas/RelationshipEdge";
 import { createTestContext, createWorkspace } from "./helpers";
 
 test("selecting an element emphasizes only its directly connected relationships", () => {
@@ -9,6 +12,14 @@ test("selecting an element emphasizes only its directly connected relationships"
   expect(relationshipFocus("a", "a", "b")).toBe("connected");
   expect(relationshipFocus("b", "a", "b")).toBe("connected");
   expect(relationshipFocus("c", "a", "b")).toBe("dimmed");
+});
+
+test("relationship labels use an opaque card background", () => {
+  expect(relationshipLabelBackground("normal")).toBe("var(--card)");
+  expect(relationshipLabelBackground("dimmed")).toBe("var(--card)");
+  expect(relationshipLabelBackground("connected")).toBe(
+    "color-mix(in oklch, var(--primary) 12%, var(--card))",
+  );
 });
 
 test("presentation switches are independent, scoped to a view and undoable without moving cards", () => {


### PR DESCRIPTION
## What and why

Fixes the editor workflow issues found while reproducing the demo on a clean workspace:

- select a newly created relationship or boundary immediately so its inspector opens;
- use an autofocused multiline field for relationship descriptions;
- make "Start with: All elements" include only recursive descendants when a scope is selected, excluding the scope itself and unrelated workspace elements;
- keep a visible parent as a regular Dagre node, matching how the canvas renders it and preserving relationship constraints without cluster-edge crashes;
- label derived parent frames with the parent element kind instead of the hardcoded Deployment layer;
- render relationship label chips above connection lines with an opaque background.

The work is split into five focused commits covering creation selection, scoped view seeding, parent layout semantics, relationship description editing, and relationship label stacking.

## How to verify

1. Run `bun test`, `bun run typecheck`, `bun run check`, and `bun run build`.
2. Create a relationship on the canvas and confirm its inspector opens with Description focused.
3. Add a boundary and confirm its inspector opens immediately.
4. Create a container view with a scope and "All elements"; confirm only descendants are seeded.
5. Auto-layout a manual view containing a parent, its children, and a relationship to the parent; confirm the relationship affects LR/TB placement and no error toast appears.
6. Open a view where a hidden parent is represented by a derived frame; confirm its header shows the element kind rather than Deployment.
7. Confirm relationship labels cover their connection lines instead of rendering underneath them.

## Checklist

- [x] `bun run check`, `bun run typecheck`, `bun run test` and `bun run build` pass
- [x] The semantic model stays the source of truth — no data lives only in React Flow state
- [x] Layout changes touch views, not elements
- [x] REST and MCP still go through the same domain services
- [x] No new DTOs are required
- [x] No new user-facing copy was added