### PR TITLE
fix(canvas): preserve nested boundary headers

### DIFF
--- a/apps/web/src/features/canvas/BoundaryNode.tsx
+++ b/apps/web/src/features/canvas/BoundaryNode.tsx
@@ -26,7 +26,7 @@ function BoundaryNodeComponent({ data, selected }: NodeProps & { data: BoundaryN
       }}
     >
       <div
-        className="flex min-h-9 items-center gap-2 border-b px-3 py-2 text-xs font-bold uppercase tracking-wider backdrop-blur-sm"
+        className="flex h-9 items-center gap-2 border-b px-3 py-2 text-xs font-bold uppercase tracking-wider backdrop-blur-sm"
         style={{
           borderColor: `color-mix(in oklch, ${accent} 45%, var(--canvas))`,
           backgroundColor: `color-mix(in oklch, ${accent} 34%, var(--canvas))`,

--- a/apps/web/src/features/canvas/Canvas.tsx
+++ b/apps/web/src/features/canvas/Canvas.tsx
@@ -39,8 +39,7 @@ import { ElementNode } from "./ElementNode";
 import {
   boundaryElementId,
   buildGraph,
-  computeBoundaries,
-  computeSemanticBoundaries,
+  computeCanvasBoundaries,
   type FlowEdge,
   type FlowNode,
   isBoundaryId,
@@ -821,28 +820,26 @@ export function Canvas({
         width: node.measured?.width ?? node.width ?? NODE_WIDTH,
         height: node.measured?.height ?? node.height ?? NODE_HEIGHT,
       }));
-    // A parent shown as a boundary has no entry in `nodes`, so mirror the
-    // selection onto it here.
-    const legacyBoundaries = computeBoundaries(
+    const computedBoundaries = computeCanvasBoundaries(
       sources,
       elementsById,
+      boundaries,
+      view.settings.boundaryLayer,
       view.settings.showBoundaries,
-    ).map((boundary) => ({
+    );
+    // A parent shown as a boundary has no entry in `nodes`, so mirror the
+    // selection onto it here.
+    const legacyBoundaries = computedBoundaries.parentBoundaries.map((boundary) => ({
       ...boundary,
       selected:
         (selection.type === "element" && selection.id === boundaryElementId(boundary.id)) ||
         (selection.type === "elements" && selection.ids.includes(boundaryElementId(boundary.id))),
     }));
-    const semanticBoundaries = computeSemanticBoundaries(
-      sources,
-      boundaries,
-      view.settings.boundaryLayer,
-      view.settings.showBoundaries,
-    ).map((boundary) => ({
+    const semanticBoundaries = computedBoundaries.semanticBoundaries.map((boundary) => ({
       ...boundary,
       selected: selection.type === "boundary" && selection.id === boundary.data.boundaryId,
     }));
-    return [...semanticBoundaries, ...legacyBoundaries, ...nodes];
+    return [...legacyBoundaries, ...semanticBoundaries, ...nodes];
   }, [
     nodes,
     elementsById,

--- a/apps/web/src/features/canvas/graph.ts
+++ b/apps/web/src/features/canvas/graph.ts
@@ -16,8 +16,8 @@ import type { Edge, Node } from "@xyflow/react";
 
 export const NODE_WIDTH = DEFAULT_NODE_WIDTH;
 export const NODE_HEIGHT = DEFAULT_NODE_HEIGHT;
-const BOUNDARY_PADDING = 28;
-const BOUNDARY_HEADER = 26;
+export const BOUNDARY_PADDING = 28;
+export const BOUNDARY_HEADER = 36;
 
 export interface ElementNodeData extends Record<string, unknown> {
   element: ArchitectureElement;
@@ -165,6 +165,10 @@ export interface BoundarySource {
   height: number;
 }
 
+interface NestedBoundarySource extends BoundarySource {
+  elementIds: readonly string[];
+}
+
 function boundaryStyle(
   classification: ArchitectureBoundary["classification"],
   width: number,
@@ -194,6 +198,7 @@ export function computeBoundaries(
   sources: readonly BoundarySource[],
   elementsById: ReadonlyMap<string, ArchitectureElement>,
   enabled: boolean,
+  nestedBoundaries: readonly NestedBoundarySource[] = [],
 ): FlowNode[] {
   if (!enabled) return [];
 
@@ -206,6 +211,28 @@ export function computeBoundaries(
     const bucket = groups.get(parentId);
     if (bucket) bucket.push(source);
     else groups.set(parentId, [source]);
+  }
+
+  // A semantic boundary can sit inside a parent-element frame. Include the
+  // entire nested rectangle in that parent's footprint, rather than deriving
+  // both frames independently from the same cards and overlapping headers.
+  for (const boundary of nestedBoundaries) {
+    const parentIds = new Set(
+      boundary.elementIds
+        .map((elementId) => elementsById.get(elementId)?.parentId)
+        .filter(
+          (parentId): parentId is string =>
+            parentId !== null && parentId !== undefined && !present.has(parentId),
+        ),
+    );
+    for (const parentId of parentIds) {
+      const bucket = groups.get(parentId);
+      if (bucket) {
+        if (!bucket.some((source) => source.id === boundary.id)) bucket.push(boundary);
+      } else {
+        groups.set(parentId, [boundary]);
+      }
+    }
   }
 
   const nodes: FlowNode[] = [];
@@ -326,11 +353,70 @@ export function computeSemanticBoundaries(
         selectable: false,
         connectable: false,
         deletable: false,
-        zIndex: depth,
+        // Parent-element frames use zero. Semantic boundaries sit above them,
+        // and each nested semantic level sits above its parent.
+        zIndex: depth + 1,
         style: boundaryStyle(boundary.classification, box.width, box.height),
       },
     ];
   });
+}
+
+/** Compute both boundary systems together so their boxes form one visual hierarchy. */
+export function computeCanvasBoundaries(
+  sources: readonly BoundarySource[],
+  elementsById: ReadonlyMap<string, ArchitectureElement>,
+  boundaries: readonly ArchitectureBoundary[],
+  layer: ArchitectureBoundary["layer"],
+  enabled: boolean,
+): { parentBoundaries: FlowNode[]; semanticBoundaries: FlowNode[] } {
+  const semanticBoundaries = computeSemanticBoundaries(sources, boundaries, layer, enabled);
+  if (!enabled) return { parentBoundaries: [], semanticBoundaries };
+
+  const active = boundaries.filter((boundary) => boundary.layer === layer);
+  const children = new Map<string, ArchitectureBoundary[]>();
+  for (const boundary of active) {
+    if (!boundary.parentBoundaryId) continue;
+    const bucket = children.get(boundary.parentBoundaryId);
+    if (bucket) bucket.push(boundary);
+    else children.set(boundary.parentBoundaryId, [boundary]);
+  }
+
+  const members = new Map<string, Set<string>>();
+  const memberIds = (boundaryId: string, visiting = new Set<string>()): Set<string> => {
+    const cached = members.get(boundaryId);
+    if (cached) return cached;
+    if (visiting.has(boundaryId)) return new Set();
+    visiting.add(boundaryId);
+    const boundary = active.find((candidate) => candidate.id === boundaryId);
+    const result = new Set(boundary?.elementIds ?? []);
+    for (const child of children.get(boundaryId) ?? []) {
+      for (const elementId of memberIds(child.id, visiting)) result.add(elementId);
+    }
+    visiting.delete(boundaryId);
+    members.set(boundaryId, result);
+    return result;
+  };
+
+  const nestedBoundaries = semanticBoundaries.flatMap((node): NestedBoundarySource[] => {
+    const boundaryId = node.data.boundaryId;
+    if (!boundaryId || node.width === undefined || node.height === undefined) return [];
+    return [
+      {
+        id: node.id,
+        x: node.position.x,
+        y: node.position.y,
+        width: node.width,
+        height: node.height,
+        elementIds: [...memberIds(String(boundaryId))],
+      },
+    ];
+  });
+
+  return {
+    parentBoundaries: computeBoundaries(sources, elementsById, enabled, nestedBoundaries),
+    semanticBoundaries,
+  };
 }
 
 export const isBoundaryId = (id: string): boolean => id.startsWith("boundary:");

--- a/tests/boundaries.test.ts
+++ b/tests/boundaries.test.ts
@@ -1,7 +1,10 @@
 import { describe, expect, test } from "bun:test";
 import { computeLayout, toMermaid, validateDocument } from "@structsmith/domain";
 import {
+  BOUNDARY_HEADER,
+  BOUNDARY_PADDING,
   computeBoundaries,
+  computeCanvasBoundaries,
   computeSemanticBoundaries,
 } from "../apps/web/src/features/canvas/graph";
 import { createTestContext, createWorkspace } from "./helpers";
@@ -35,6 +38,77 @@ describe("semantic boundaries", () => {
         elementId: system.id,
       });
       expect(frames[0]?.data).not.toHaveProperty("layer");
+    } finally {
+      close();
+    }
+  });
+
+  test("nests semantic boundary headers inside a derived parent frame", () => {
+    const { services, close } = createTestContext();
+    try {
+      const workspace = createWorkspace(services);
+      const system = services.elements.create(workspace.id, {
+        kind: "softwareSystem",
+        name: "HaloKierowca",
+      }).result;
+      const mobile = services.elements.create(workspace.id, {
+        kind: "container",
+        parentId: system.id,
+        name: "Mobile app",
+      }).result;
+      const api = services.elements.create(workspace.id, {
+        kind: "container",
+        parentId: system.id,
+        name: "API",
+      }).result;
+      const view = services.views.create(workspace.id, {
+        kind: "container",
+        name: "Architecture",
+        elementIds: [mobile.id, api.id],
+      }).result;
+      const clients = services.boundaries.create(workspace.id, {
+        viewId: view.id,
+        kind: "custom",
+        name: "Client applications",
+      }).result;
+      services.boundaries.create(workspace.id, {
+        viewId: view.id,
+        parentBoundaryId: clients.id,
+        kind: "networkZone",
+        name: "Mobile zone",
+        elementIds: [mobile.id],
+      });
+      const elements = services.elements.list(workspace.id);
+
+      const result = computeCanvasBoundaries(
+        [
+          { id: mobile.id, x: 100, y: 100, width: 220, height: 96 },
+          { id: api.id, x: 500, y: 300, width: 220, height: 96 },
+        ],
+        new Map(elements.map((element) => [element.id, element] as const)),
+        services.views.get(view.id).boundaries,
+        "deployment",
+        true,
+      );
+
+      expect(result.parentBoundaries).toHaveLength(1);
+      expect(result.semanticBoundaries).toHaveLength(2);
+      const parent = result.parentBoundaries[0];
+      const clientFrame = result.semanticBoundaries.find(
+        (boundary) => boundary.data.name === "Client applications",
+      );
+      const mobileFrame = result.semanticBoundaries.find(
+        (boundary) => boundary.data.name === "Mobile zone",
+      );
+      if (!parent || !clientFrame || !mobileFrame) throw new Error("Missing nested boundaries");
+
+      expect(clientFrame.position.x - parent.position.x).toBe(BOUNDARY_PADDING);
+      expect(clientFrame.position.y - parent.position.y).toBe(BOUNDARY_PADDING + BOUNDARY_HEADER);
+      expect(mobileFrame.position.x - clientFrame.position.x).toBe(BOUNDARY_PADDING);
+      expect(mobileFrame.position.y - clientFrame.position.y).toBe(
+        BOUNDARY_PADDING + BOUNDARY_HEADER,
+      );
+      expect([parent.zIndex, clientFrame.zIndex, mobileFrame.zIndex]).toEqual([0, 1, 2]);
     } finally {
       close();
     }


### PR DESCRIPTION
## What and why

Parent-derived frames and semantic boundaries were computed independently from the same element cards. Their top edges could therefore coincide, which made nested boundary headers overlap or disappear. Top-level frames also shared the same z-index, so the outer frame could obscure the inner one.

This change:

- computes semantic boundaries first and includes their full rectangles in derived parent-frame footprints;
- carries recursive boundary member IDs so nested semantic boundaries stay inside the correct architecture parent;
- assigns semantic boundary z-indexes from 1 upward, keeping derived parent frames behind them;
- aligns the layout geometry with the rendered 36 px boundary header.

Verified against the HaloKierowca `v-arch` data: the outer frame header ends at `y=112`, while the nested Applications boundary starts at `y=140`, preserving the intended 28 px gap.

## How to verify

1. Run `bun test`, `bun run typecheck`, `bun run check`, and `bun run build`.
2. Open `http://localhost:3500/w/halokierowca?view=v-arch`.
3. Confirm that the HaloKierowca frame contains the Applications and AWS boundary frames without covering their headers.
4. Confirm that nested semantic boundaries retain one header height plus boundary padding at each level.

## Checklist

- [x] `bun run check`, `bun run typecheck`, `bun run test` and `bun run build` pass
- [x] The semantic model stays the source of truth — no data lives only in React Flow state
- [x] Layout changes touch views, not elements
- [x] REST and MCP still go through the same domain services
- [x] No new DTOs are required
- [x] No user-facing copy was added