### PR TITLE
docs(changelog): update for v1.9.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [1.9.3](https://github.com/dziksu/structsmith/compare/v1.9.2...v1.9.3) (2026-09-11)
+
+### Bug Fixes
+
+* **canvas:** preserve nested boundary headers ([e8d1beb](https://github.com/dziksu/structsmith/commit/e8d1beb19a31552a56f14dba0fda0e2b670e7045))
+
 ## [1.9.2](https://github.com/dziksu/structsmith/compare/v1.9.1...v1.9.2) (2026-09-11)
 
 ### Bug Fixes

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "structsmith",
   "private": true,
-  "version": "1.9.2",
+  "version": "1.9.3",
   "license": "MIT",
   "description": "Local-first, MCP-native tool for modelling software architecture — a self-hosted alternative to Structurizr with a React Flow editor.",
   "keywords": [


### PR DESCRIPTION
Automated release metadata update generated by semantic-release.

Release: v1.9.3
Updates: CHANGELOG.md and the application version in package.json